### PR TITLE
Iterate on documentation, again

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Blinksy
+# Blinksy 🟥🟩🟦
 
-Blinksy is a **Rust** **no-std**, **no-alloc** LED control library designed for 1D, 2D, and 3D (audio-reactive) LED setups, inspired by [FastLED](https://fastled.io/) and [WLED](https://kno.wled.ge/).
+Blinksy is a **Rust** **no-std**, **no-alloc** LED control library for 1D, 2D, and soon 3D LED setups, inspired by [FastLED](https://fastled.io/) and [WLED](https://kno.wled.ge/).
 
 ## How Blinksy works
 
-- Define LED layouts in 1D, 2D, or 3D space
+- Define LED layouts in 1D, 2D, or soon 3D space
 - Create your visual pattern (effect), or choose from our built-in library
   - The pattern will compute colors for each LED based on its position
 - Drive various LED chipsets with each frame of colors
@@ -12,7 +12,7 @@ Blinksy is a **Rust** **no-std**, **no-alloc** LED control library designed for 
 ## Features
 
 - **No-std, No-alloc:** Designed to run on embedded targets.
-- **Layout Abstraction:** Define 1D, 2D, or 3D LED positions with shapes (grids, lines, arcs, points, etc).
+- **Layout Abstraction:** Define 1D, 2D, or soon 3D LED positions with shapes (grids, lines, arcs, points, etc).
 - **Pattern (Effect) Library:**
   - **Rainbow**
   - **Noise**
@@ -55,7 +55,7 @@ https://github.com/user-attachments/assets/1c1cf3a2-f65c-4152-b444-29834ac749ee
 use blinksy::{
     layout::{Shape2d, Vec2},
     layout2d,
-    patterns::{noise_fns, Noise2d, NoiseParams},
+    patterns::noise::{noise_fns, Noise2d, NoiseParams},
     ControlBuilder,
 };
 use gledopto::{apa102, board, elapsed, main};
@@ -103,7 +103,7 @@ https://github.com/user-attachments/assets/703fe31d-e7ca-4e08-ae2b-7829c0d4d52e
 use blinksy::{
     layout::Layout1d,
     layout1d,
-    patterns::{Rainbow, RainbowParams},
+    patterns::rainbow::{Rainbow, RainbowParams},
     ControlBuilder,
 };
 use gledopto::{board, elapsed, main, ws2812};

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Blinksy is a **Rust** **no-std**, **no-alloc** LED control library designed for 
 - **No-std, No-alloc:** Designed to run on embedded targets.
 - **Layout Abstraction:** Define 1D, 2D, or 3D LED positions with shapes (grids, lines, arcs, points, etc).
 - **Pattern (Effect) Library:**
-  - **Rainbow**:
+  - **Rainbow**
   - **Noise**
   - [Make an issue](https://github.com/ahdinosaur/blinksy/issues) if you want help to port a pattern from FastLED / WLED to Rust!
 - **Multi‑Chipset Support:**
@@ -24,8 +24,11 @@ Blinksy is a **Rust** **no-std**, **no-alloc** LED control library designed for 
 - **Board Support Packages**:
   - **Gledopto**: A great LED controller available on AliExpress: [Gledopto GL-C-016WL-D](https://www.aliexpress.com/item/1005008707989546.html)
   - (TODO) [**QuinLED**](https://quinled.info/): The best DIY and pre-assembled LED controller boards
+- **RGBW Support:** Supports RGB + White color channels
 - **Desktop Simulation:** Run a simulation of a layout and pattern on your computer to experiment with ideas.
-- (TODO) **Audio-Reactive**: Easily integrate audio reactivity into visual patterns.
+- (TODO) **Audio-Reactive**: Easily integrate audio reactivity into visual patterns. ([#9](https://github.com/ahdinosaur/blinksy/issues/9))
+- (TODO) **Advanced LED Calibration**: Supports color correction based on LED-specific spectrometer data. ([#24](https://github.com/ahdinosaur/blinksy/issues/24))
+- (TODO) **Multi-LED Solver**: Supports LEDs with color channels beyond RGB or RGBW. ([#23](https://github.com/ahdinosaur/blinksy/issues/23))
 
 ## Modules
 

--- a/blinksy-desktop/examples/1d-rainbow.rs
+++ b/blinksy-desktop/examples/1d-rainbow.rs
@@ -1,6 +1,6 @@
 use blinksy::{
     layout1d,
-    patterns::{Rainbow, RainbowParams},
+    patterns::rainbow::{Rainbow, RainbowParams},
     ControlBuilder,
 };
 use blinksy_desktop::{

--- a/blinksy-desktop/examples/1d-rainbow.rs
+++ b/blinksy-desktop/examples/1d-rainbow.rs
@@ -4,7 +4,7 @@ use blinksy::{
     ControlBuilder,
 };
 use blinksy_desktop::{
-    drivers::{Desktop, DesktopError},
+    driver::{Desktop, DesktopError},
     time::elapsed_in_ms,
 };
 use std::{thread::sleep, time::Duration};

--- a/blinksy-desktop/examples/2d-noise.rs
+++ b/blinksy-desktop/examples/2d-noise.rs
@@ -1,7 +1,7 @@
 use blinksy::{
     layout::{Shape2d, Vec2},
     layout2d,
-    patterns::{noise_fns, Noise2d, NoiseParams},
+    patterns::noise::{noise_fns, Noise2d, NoiseParams},
     ControlBuilder,
 };
 use blinksy_desktop::{

--- a/blinksy-desktop/examples/2d-noise.rs
+++ b/blinksy-desktop/examples/2d-noise.rs
@@ -5,7 +5,7 @@ use blinksy::{
     ControlBuilder,
 };
 use blinksy_desktop::{
-    drivers::{Desktop, DesktopError},
+    driver::{Desktop, DesktopError},
     time::elapsed_in_ms,
 };
 use std::{thread::sleep, time::Duration};

--- a/blinksy-desktop/examples/2d-rainbow.rs
+++ b/blinksy-desktop/examples/2d-rainbow.rs
@@ -5,7 +5,7 @@ use blinksy::{
     ControlBuilder,
 };
 use blinksy_desktop::{
-    drivers::{Desktop, DesktopError},
+    driver::{Desktop, DesktopError},
     time::elapsed_in_ms,
 };
 use std::{thread::sleep, time::Duration};

--- a/blinksy-desktop/examples/2d-rainbow.rs
+++ b/blinksy-desktop/examples/2d-rainbow.rs
@@ -1,7 +1,7 @@
 use blinksy::{
     layout::{Shape2d, Vec2},
     layout2d,
-    patterns::{Rainbow, RainbowParams},
+    patterns::rainbow::{Rainbow, RainbowParams},
     ControlBuilder,
 };
 use blinksy_desktop::{

--- a/blinksy-desktop/src/driver.rs
+++ b/blinksy-desktop/src/driver.rs
@@ -1,10 +1,11 @@
 //! # Desktop Simulation Driver
 //!
 //! This module provides a graphical simulation of LED layouts and patterns for desktop development
-//! and debugging. It implements the `Driver` trait, allowing it to be used as a drop-in
+//! and debugging. It implements the [`Driver`] trait, allowing it to be used as a drop-in
 //! replacement for physical LED hardware.
 //!
 //! The simulator creates a 3D visualization window where:
+//!
 //! - LEDs are represented as small 3D objects
 //! - LED positions match the layout's physical arrangement
 //! - Colors and brightness updates are displayed in real-time
@@ -25,7 +26,7 @@
 //!     layout::{Shape2d, Vec2},
 //!     patterns::rainbow::{Rainbow, RainbowParams}
 //! };
-//! use blinksy_desktop::{drivers::Desktop, time::elapsed_in_ms};
+//! use blinksy_desktop::{driver::Desktop, time::elapsed_in_ms};
 //!
 //! // Define your layout
 //! layout2d!(
@@ -53,6 +54,8 @@
 //!     std::thread::sleep(std::time::Duration::from_millis(16));
 //! }
 //! ```
+//!
+//! [`Driver`]: blinksy::driver::Driver
 
 use blinksy::{
     color::{ColorCorrection, FromColor, LinearSrgb, Srgb},

--- a/blinksy-desktop/src/driver.rs
+++ b/blinksy-desktop/src/driver.rs
@@ -1,7 +1,7 @@
 //! # Desktop Simulation Driver
 //!
 //! This module provides a graphical simulation of LED layouts and patterns for desktop development
-//! and debugging. It implements the `LedDriver` trait, allowing it to be used as a drop-in
+//! and debugging. It implements the `Driver` trait, allowing it to be used as a drop-in
 //! replacement for physical LED hardware.
 //!
 //! The simulator creates a 3D visualization window where:
@@ -23,7 +23,7 @@
 //!     ControlBuilder,
 //!     layout2d,
 //!     layout::{Shape2d, Vec2},
-//!     patterns::{Rainbow, RainbowParams}
+//!     patterns::rainbow::{Rainbow, RainbowParams}
 //! };
 //! use blinksy_desktop::{drivers::Desktop, time::elapsed_in_ms};
 //!
@@ -57,7 +57,7 @@
 use blinksy::{
     color::{ColorCorrection, FromColor, LinearSrgb, Srgb},
     dimension::{Dim1d, Dim2d, LayoutForDim},
-    driver::LedDriver,
+    driver::Driver,
     layout::{Layout1d, Layout2d},
 };
 use core::{fmt, marker::PhantomData};
@@ -109,7 +109,7 @@ impl Default for DesktopConfig {
 
 /// Desktop driver for simulating LED layouts in a desktop window.
 ///
-/// This struct implements the `LedDriver` trait and renders a visual
+/// This struct implements the `Driver` trait and renders a visual
 /// representation of your LED layout using miniquad.
 ///
 /// # Type Parameters
@@ -305,7 +305,7 @@ enum LedMessage {
     Quit,
 }
 
-impl<Dim, Layout> LedDriver for Desktop<Dim, Layout>
+impl<Dim, Layout> Driver for Desktop<Dim, Layout>
 where
     Layout: LayoutForDim<Dim>,
 {

--- a/blinksy-desktop/src/lib.rs
+++ b/blinksy-desktop/src/lib.rs
@@ -19,7 +19,7 @@
 //!     ControlBuilder,
 //!     layout2d,
 //!     layout::{Shape2d, Vec2},
-//!     patterns::{Rainbow, RainbowParams}
+//!     patterns::rainbow::{Rainbow, RainbowParams}
 //! };
 //! use blinksy_desktop::{drivers::Desktop, time::elapsed_in_ms};
 //!

--- a/blinksy-desktop/src/lib.rs
+++ b/blinksy-desktop/src/lib.rs
@@ -4,14 +4,6 @@
 //! It allows you to visualize LED layouts and patterns in a 3D graphical window,
 //! making development and testing possible without physical LED hardware.
 //!
-//! ## Features
-//!
-//! - 3D visualization of LED layouts
-//! - Real-time display of patterns and animations
-//! - Interactive camera controls for viewing from different angles
-//! - Drop-in replacement for physical LED drivers
-//! - Compatible with all Blinksy layouts and patterns
-//!
 //! ## Usage
 //!
 //! ```rust,no_run
@@ -21,7 +13,7 @@
 //!     layout::{Shape2d, Vec2},
 //!     patterns::rainbow::{Rainbow, RainbowParams}
 //! };
-//! use blinksy_desktop::{drivers::Desktop, time::elapsed_in_ms};
+//! use blinksy_desktop::{driver::Desktop, time::elapsed_in_ms};
 //!
 //! // Define your layout
 //! layout2d!(
@@ -49,18 +41,9 @@
 //!     std::thread::sleep(std::time::Duration::from_millis(16));
 //! }
 //! ```
-//!
-//! ## Modules
-//!
-//! - [`drivers`]: Desktop LED simulation
-//! - [`time`]: Time utilities
 
-mod driver;
+/// Desktop LED simulation
+pub mod driver;
 
 /// Time utilities
 pub mod time;
-
-/// Desktop LED simulation
-pub mod drivers {
-    pub use crate::driver::*;
-}

--- a/blinksy-desktop/src/time.rs
+++ b/blinksy-desktop/src/time.rs
@@ -1,8 +1,6 @@
 //! # Time Utilities
 //!
-//! This module provides timing utilities for the desktop simulation environment.
-//! It enables consistent time tracking for animation updates, allowing simulations
-//! to run at the correct speed.
+//! This module helps you with time in the desktop simulation environment.
 //!
 //! ## Example
 //!

--- a/blinksy/src/color/convert.rs
+++ b/blinksy/src/color/convert.rs
@@ -1,8 +1,12 @@
+/// Trait for converting from another color type
 pub trait FromColor<Color>: Sized {
+    /// Converts from the source color type
     fn from_color(color: Color) -> Self;
 }
 
+/// Trait for converting to another color type
 pub trait IntoColor<Color>: Sized {
+    /// Converts into the target color type
     fn into_color(self) -> Color;
 }
 

--- a/blinksy/src/color/correction.rs
+++ b/blinksy/src/color/correction.rs
@@ -11,7 +11,6 @@
 /// - You need a white point correction for your specific LEDs
 /// - Calibrating a display system for accurate color reproduction
 /// - Compensating for RGB LED intensity differences
-///
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ColorCorrection {
     /// Scaling factor for red channel
@@ -76,8 +75,6 @@ impl ColorCorrection {
     /// let cool = ColorCorrection::from_temperature(6500);
     /// ```
     pub fn from_temperature(temperature: u32) -> Self {
-        // Simple approximation of color temperature correction
-        // This is a very basic model and could be improved
         let temp = temperature.clamp(1000, 40000) as f32;
         let temp = (temp - 1000.0) / 39000.0;
 

--- a/blinksy/src/color/gamma_srgb.rs
+++ b/blinksy/src/color/gamma_srgb.rs
@@ -1,5 +1,4 @@
 use super::LinearSrgb;
-
 #[allow(unused_imports)]
 use num_traits::Float;
 

--- a/blinksy/src/color/linear_srgb.rs
+++ b/blinksy/src/color/linear_srgb.rs
@@ -64,6 +64,17 @@ impl LinearSrgb {
         GammaSrgb::from_linear_srgb(self, gamma)
     }
 
+    /// Converts to LED output color values
+    ///
+    /// # Arguments
+    ///
+    /// * `channels` - The LED channel format specification
+    /// * `brightness` - Global brightness scaling factor (0.0 to 1.0)
+    /// * `correction` - Color correction factors for the LEDs
+    ///
+    /// # Returns
+    ///
+    /// A `LedColor` in the specified component type, ready for output to hardware
     pub fn to_led<C: Component>(
         self,
         channels: LedChannels,

--- a/blinksy/src/color/lms.rs
+++ b/blinksy/src/color/lms.rs
@@ -9,11 +9,10 @@ use super::LinearSrgb;
 /// - M (Medium) cones: Most sensitive to medium wavelengths (greenish)
 /// - S (Short) cones: Most sensitive to short wavelengths (bluish)
 ///
-/// ## Properties
+/// ## Color Space Properties
 ///
-/// - **Device-independent**: Based on human perception
+/// - **Device-Independent**: Based on human perception
 /// - **White Point**: D65 (6500K), same as sRGB
-/// - **Use Cases**: Color adaptation, vision deficiency simulation
 ///
 /// LMS is primarily used as an intermediate space for color processing algorithms,
 /// particularly those that simulate or account for human color vision characteristics.
@@ -49,7 +48,6 @@ impl Lms {
         ];
 
         let LinearSrgb { red, green, blue } = linear_srgb;
-
         let long = LINEAR_SRGB_TO_LMS[0][0] * red
             + LINEAR_SRGB_TO_LMS[0][1] * green
             + LINEAR_SRGB_TO_LMS[0][2] * blue;
@@ -78,7 +76,6 @@ impl Lms {
             medium,
             short,
         } = self;
-
         let red = LMS_TO_LINEAR_SRGB[0][0] * long
             + LMS_TO_LINEAR_SRGB[0][1] * medium
             + LMS_TO_LINEAR_SRGB[0][2] * short;

--- a/blinksy/src/color/mod.rs
+++ b/blinksy/src/color/mod.rs
@@ -1,4 +1,24 @@
 //! # Color Types and Utilities
+//!
+//! This module provides types and utilities for working with different color spaces,
+//! color conversions, and LED color representation.
+//!
+//! ## Color Spaces
+//!
+//! - [`Srgb`] - Standard RGB color space (gamma-corrected)
+//! - [`LinearSrgb`] - Linear RGB color space (no gamma correction)
+//! - [`GammaSrgb`] - RGB with custom gamma correction
+//! - [`Xyz`] - CIE XYZ color space
+//! - [`Lms`] - LMS cone response space
+//! - [`Oklab`] - Perceptually uniform LAB space
+//! - [`Okhsl`] - Perceptual HSL color space based on Oklab
+//! - [`Okhsv`] - Perceptual HSV color space based on Oklab
+//!
+//! ## LED Color Handling
+//!
+//! - [`LedColor`] - Output-ready color data for LED hardware
+//! - [`ColorCorrection`] - Correction factors for LED output
+//! - [`LedChannels`] - Color channel formats for different LED chipsets
 
 mod convert;
 mod correction;

--- a/blinksy/src/color/okhsl.rs
+++ b/blinksy/src/color/okhsl.rs
@@ -4,10 +4,15 @@ use num_traits::Euclid;
 #[allow(unused_imports)]
 use num_traits::Float;
 
-/// Okhsl color space representation.
+/// # Okhsl Color Space
 ///
-/// A color space based on Oklab that uses the more intuitive
-/// hue, saturation, and lightness components.
+/// A color space based on Oklab that uses the more intuitive hue, saturation,
+/// and lightness components. This provides a perceptually uniform alternative
+/// to traditional HSL models.
+///
+/// - `h`: Hue component (0.0 to 1.0) representing the color's position on the color wheel
+/// - `s`: Saturation component (0.0 to 1.0) representing the color's intensity/purity
+/// - `l`: Lightness component (0.0 to 1.0) representing the color's brightness
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Okhsl {
     /// Hue component [0.0, 1.0) where 0 and 1 both represent red

--- a/blinksy/src/color/okhsv.rs
+++ b/blinksy/src/color/okhsv.rs
@@ -4,10 +4,14 @@ use num_traits::Euclid;
 #[allow(unused_imports)]
 use num_traits::Float;
 
-/// Okhsv color space representation.
+/// # Okhsv Color Space
 ///
-/// A color space based on Oklab that uses hue, saturation,
-/// and value (brightness) components.
+/// A color space based on Oklab that uses hue, saturation, and value (brightness) components.
+/// This provides a perceptually uniform way to represent colors in the familiar HSV model.
+///
+/// - `h`: Hue component (0.0 to 1.0) representing the color's position on the color wheel
+/// - `s`: Saturation component (0.0 to 1.0) representing the color's intensity/purity
+/// - `v`: Value/brightness component (0.0 to 1.0) representing the color's luminosity
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Okhsv {
     /// Hue component [0.0, 1.0] where 0 and 1 both represent red
@@ -32,14 +36,8 @@ impl Okhsv {
     /// Converts Okhsv to Oklab.
     pub fn to_oklab(&self) -> Oklab {
         let v = self.v;
-
-        // Calculate max chroma for this value
         let max_c = 0.4 * v;
-
-        // Calculate chroma
         let c = self.s * max_c;
-
-        // Convert hue and chroma to a, b components
         let angle = 2.0 * core::f32::consts::PI * self.h;
         let a = c * angle.cos();
         let b = c * angle.sin();

--- a/blinksy/src/color/oklab.rs
+++ b/blinksy/src/color/oklab.rs
@@ -23,7 +23,7 @@ use num_traits::Float;
 ///
 /// - **White Point**: D65 (6500K), same as sRGB
 ///
-/// Reference: https://bottosson.github.io/posts/oklab/
+/// Reference: <https://bottosson.github.io/posts/oklab/>
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Oklab {
     /// Lightness component [0.0, 1.0]

--- a/blinksy/src/color/oklab.rs
+++ b/blinksy/src/color/oklab.rs
@@ -1,5 +1,4 @@
 use super::{LinearSrgb, Lms};
-
 #[allow(unused_imports)]
 use num_traits::Float;
 
@@ -9,8 +8,6 @@ use num_traits::Float;
 /// blending characteristics compared to traditional spaces like sRGB or
 /// CIELAB. Its goal is to make mathematical color operations align more
 /// closely with how humans perceive color differences.
-///
-/// It represents colors using three components:
 ///
 /// - `l`: **Perceptual Lightness**. This value typically ranges from 0.0 (black)
 ///   to 1.0 (white). Changes in `l` are intended to correspond linearly
@@ -22,34 +19,9 @@ use num_traits::Float;
 ///   and positive values lean towards yellow. A value near zero is neutral grey
 ///   along this axis.
 ///
-/// ## Properties
+/// ## Color Space Properties
 ///
 /// - **White Point**: D65 (6500K), same as sRGB
-///
-/// Oklab, like many standard color spaces, is based on the D65 whitepoint,
-/// which represents average daylight.
-///
-/// ## Why Use Oklab?
-///
-/// The primary advantage of Oklab is its **perceptual uniformity**. This means
-/// that a small change in the Oklab coordinates (i.e., a small Euclidean
-/// distance in the 3D Oklab space) corresponds more closely to a small,
-/// equally perceived difference in color by a human observer, regardless
-/// of the color's initial hue, lightness, or chroma.
-///
-/// This property makes Oklab excellent for:
-///
-/// - **Color Gradients and Interpolation:** Blending colors in Oklab
-///   often results in smoother, more natural-looking transitions without
-///   undesirable "greyish" or "muddy" intermediate colors sometimes seen
-///   when blending in sRGB.
-/// - **Image Processing:** Operations like desaturation, adjusting
-///   lightness, or manipulating contrast can be performed in Oklab with
-///   less risk of affecting the perceived hue or introducing artifacts.
-///   For example, simply setting `a` and `b` to zero effectively grayscales
-///   a color while preserving its *perceived* lightness.
-/// - **Color Picking Interfaces:** Providing a more intuitive way for users
-///   to select and manipulate colors based on how they are seen.
 ///
 /// Reference: https://bottosson.github.io/posts/oklab/
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -101,7 +73,6 @@ impl Oklab {
             medium,
             short,
         } = lms;
-
         let l_cbrt = long.cbrt();
         let m_cbrt = medium.cbrt();
         let s_cbrt = short.cbrt();
@@ -131,7 +102,6 @@ impl Oklab {
         ];
 
         let Oklab { l, a, b } = self;
-
         let l_cbrt =
             OKLAB_TO_LMS_CBRT[0][0] * l + OKLAB_TO_LMS_CBRT[0][1] * a + OKLAB_TO_LMS_CBRT[0][2] * b;
         let m_cbrt =

--- a/blinksy/src/color/srgb.rs
+++ b/blinksy/src/color/srgb.rs
@@ -5,8 +5,8 @@ use num_traits::Float;
 
 /// # sRGB Color Space
 ///
-/// `Srgb` represents colors in the standard RGB (sRGB) color space. When you think of "just RGB",
-/// you are probably thinking of `Srgb`.
+/// `Srgb` represents colors in the standard RGB (sRGB) color space, which is
+/// the most common color space used for displays, web content, and digital images.
 ///
 /// ## Color Space Properties
 ///

--- a/blinksy/src/color/xyz.rs
+++ b/blinksy/src/color/xyz.rs
@@ -1,16 +1,19 @@
 use super::LinearSrgb;
 
-/// # CIE XYZ color space
+/// # CIE XYZ Color Space
 ///
 /// The CIE XYZ color space is a device-independent color space that models human color
-/// perception. It serves as a standard reference space for other color spaces.
+/// perception. It serves as a standard reference space for other color spaces and
+/// is often used as an intermediate step in color conversions.
 ///
-/// ## Color Space Assumptions
+/// ## Color Space Properties
 ///
 /// - **White Point**: D65 (6500K)
+/// - **Device-Independent**: Based on human perception
+/// - **Linear**: Values are proportional to light intensity
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Xyz {
-    /// X component (mix of cone responses, roughly red)
+    /// X component (mix of cone responses, roughly corresponds to red)
     pub x: f32,
     /// Y component (luminance, matches human brightness perception)
     pub y: f32,
@@ -36,7 +39,6 @@ impl Xyz {
         ];
 
         let LinearSrgb { red, green, blue } = linear_srgb;
-
         let x = LINEAR_SRGB_TO_XYZ[0][0] * red
             + LINEAR_SRGB_TO_XYZ[0][1] * green
             + LINEAR_SRGB_TO_XYZ[0][2] * blue;
@@ -54,6 +56,7 @@ impl Xyz {
     ///
     /// Uses the standard XYZ to RGB transformation matrix defined in the sRGB specification.
     /// This assumes the D65 white point used in the sRGB standard.
+    ///
     /// Note that the resulting RGB values may be outside the displayable sRGB gamut.
     pub fn to_linear_srgb(self) -> LinearSrgb {
         const XYZ_TO_LINEAR_SRGB: [[f32; 3]; 3] = [
@@ -63,7 +66,6 @@ impl Xyz {
         ];
 
         let Xyz { x, y, z } = self;
-
         let r = XYZ_TO_LINEAR_SRGB[0][0] * x
             + XYZ_TO_LINEAR_SRGB[0][1] * y
             + XYZ_TO_LINEAR_SRGB[0][2] * z;

--- a/blinksy/src/control.rs
+++ b/blinksy/src/control.rs
@@ -1,26 +1,33 @@
 //! # Control System
 //!
-//! This module provides the central control system for Blinksy, connecting layouts, patterns,
-//! and drivers together to form a complete LED control pipeline.
+//! [`Control`] is the central control system for Blinksy: connecting a layout, pattern,
+//! and driver together to form a complete LED control pipeline.
 //!
-//! - [`Control`]: The core struct that manages the LED control pipeline
-//! - [`ControlBuilder`]: A builder for creating Control instances
-//!
-//! The control system is generic over dimension, layout, pattern, and driver types.
+//! As [`Control`] has a complex generic type signature, [`ControlBuilder`] is a builder to help
+//! you create [`Control`] instances.
 
 use core::marker::PhantomData;
 
 use crate::{
     color::{ColorCorrection, FromColor},
     dimension::{Dim1d, Dim2d, LayoutForDim},
-    driver::LedDriver,
+    driver::Driver as DriverTrait,
     pattern::Pattern as PatternTrait,
 };
 
 /// Central LED control system.
 ///
-/// This struct orchestrates the flow of data from patterns to LED drivers,
-/// handling timing, color conversion, and brightness control.
+/// A [`Control`] is made up of:
+///
+/// - A [`layout`](crate::layout)
+/// - A [`pattern`](crate::pattern)
+/// - A [`driver`](crate::driver)
+///
+/// You can use [`Control`] to
+///
+/// - Set a global brightness
+/// - Set a global color correction.
+/// - Send a frame of colors from the pattern to the driver.
 ///
 /// Tip: Use [`ControlBuilder`] to build your [`Control`] struct.
 ///
@@ -37,7 +44,7 @@ use crate::{
 /// use blinksy::{
 ///     ControlBuilder,
 ///     layout1d,
-///     patterns::{Rainbow, RainbowParams}
+///     patterns::rainbow::{Rainbow, RainbowParams}
 /// };
 ///
 /// // Define a 1d layout of 60 LEDs
@@ -112,7 +119,7 @@ impl<Dim, Layout, Pattern, Driver> Control<Dim, Layout, Pattern, Driver>
 where
     Layout: LayoutForDim<Dim>,
     Pattern: PatternTrait<Dim, Layout>,
-    Driver: LedDriver,
+    Driver: DriverTrait,
     Driver::Color: FromColor<Pattern::Color>,
 {
     /// Updates the LED state based on the current time.
@@ -245,7 +252,7 @@ impl<Dim, Layout, Pattern> ControlBuilder<Dim, Layout, Pattern, ()> {
     /// Builder with driver specified
     pub fn with_driver<Driver>(self, driver: Driver) -> ControlBuilder<Dim, Layout, Pattern, Driver>
     where
-        Driver: LedDriver,
+        Driver: DriverTrait,
     {
         ControlBuilder {
             dim: self.dim,
@@ -260,7 +267,7 @@ impl<Dim, Layout, Pattern, Driver> ControlBuilder<Dim, Layout, Pattern, Driver>
 where
     Layout: LayoutForDim<Dim>,
     Pattern: PatternTrait<Dim, Layout>,
-    Driver: LedDriver,
+    Driver: DriverTrait,
     Driver::Color: FromColor<Pattern::Color>,
 {
     /// Builds the final [`Control`] struct.

--- a/blinksy/src/control.rs
+++ b/blinksy/src/control.rs
@@ -3,8 +3,6 @@
 //! This module provides the central control system for Blinksy, connecting layouts, patterns,
 //! and drivers together to form a complete LED control pipeline.
 //!
-//! The main components are:
-//!
 //! - [`Control`]: The core struct that manages the LED control pipeline
 //! - [`ControlBuilder`]: A builder for creating Control instances
 //!

--- a/blinksy/src/dimension.rs
+++ b/blinksy/src/dimension.rs
@@ -1,16 +1,9 @@
 //! # Dimension Type Markers
 //!
-//! This module provides type-level markers for representing the dimensionality of LED layouts.
-//! It allows the compiler to enforce correct combinations of layouts and patterns based on
-//! their dimensional compatibility.
-//!
-//! The core types are:
+//! Dimension markers are type-level markers to represent dimensionality.
 //!
 //! - [`Dim1d`]: Marker for one-dimensional layouts
 //! - [`Dim2d`]: Marker for two-dimensional layouts
-//!
-//! These are used as type parameters in various parts of the API to ensure
-//! dimensionally compatible combinations.
 
 use crate::layout::{Layout1d, Layout2d};
 

--- a/blinksy/src/driver/clocked/delay.rs
+++ b/blinksy/src/driver/clocked/delay.rs
@@ -19,7 +19,7 @@ use super::{ClockedLed, ClockedWriter, Driver};
 /// ```rust
 /// use embedded_hal::digital::OutputPin;
 /// use embedded_hal::delay::DelayNs;
-/// use blinksy::{driver::ClockedDelayDriver, drivers::Apa102Led};
+/// use blinksy::{driver::ClockedDelayDriver, drivers::apa102::Apa102Led};
 /// use blinksy::time::Megahertz;
 ///
 /// fn setup_leds<D, C, Delay>(

--- a/blinksy/src/driver/clocked/delay.rs
+++ b/blinksy/src/driver/clocked/delay.rs
@@ -1,43 +1,3 @@
-//! # Clocked Delay-based LED Driver
-//!
-//! This module provides an implementation of the LedDriver trait for clocked LEDs
-//! using GPIO bit-banging with a delay timer. It handles both data and clock lines
-//! to generate the protocol timing.
-//!
-//! The implementation uses:
-//!
-//! - Separate GPIO pins for data and clock
-//! - A delay provider for timing control
-//! - Parameters defined by a ClockedLed implementation
-//!
-//! ## Usage
-//!
-//! ```rust
-//! use embedded_hal::digital::OutputPin;
-//! use embedded_hal::delay::DelayNs;
-//! use blinksy::{driver::ClockedDelayDriver, drivers::Apa102Led};
-//! use blinksy::time::Megahertz;
-//!
-//! fn setup_leds<D, C, Delay>(
-//!     data_pin: D,
-//!     clock_pin: C,
-//!     delay: Delay
-//! ) -> ClockedDelayDriver<Apa102Led, D, C, Delay>
-//! where
-//!     D: OutputPin,
-//!     C: OutputPin,
-//!     Delay: DelayNs,
-//! {
-//!     // Create a new APA102 driver with 2 MHz data rate
-//!     ClockedDelayDriver::<Apa102Led, _, _, _>::new(
-//!         data_pin,
-//!         clock_pin,
-//!         delay,
-//!         Megahertz::MHz(2)
-//!     )
-//! }
-//! ```
-
 use crate::{
     color::{ColorCorrection, FromColor},
     time::{Megahertz, Nanoseconds},
@@ -46,9 +6,41 @@ use crate::{
 use core::marker::PhantomData;
 use embedded_hal::{delay::DelayNs, digital::OutputPin};
 
-use super::{ClockedLed, ClockedWriter, LedDriver};
+use super::{ClockedLed, ClockedWriter, Driver};
 
 /// Driver for clocked LEDs using GPIO bit-banging with a delay timer.
+///
+/// - Separate GPIO pins for data and clock
+/// - A delay provider for timing control
+/// - Parameters defined by a ClockedLed implementation
+///
+/// ## Usage
+///
+/// ```rust
+/// use embedded_hal::digital::OutputPin;
+/// use embedded_hal::delay::DelayNs;
+/// use blinksy::{driver::ClockedDelayDriver, drivers::Apa102Led};
+/// use blinksy::time::Megahertz;
+///
+/// fn setup_leds<D, C, Delay>(
+///     data_pin: D,
+///     clock_pin: C,
+///     delay: Delay
+/// ) -> ClockedDelayDriver<Apa102Led, D, C, Delay>
+/// where
+///     D: OutputPin,
+///     C: OutputPin,
+///     Delay: DelayNs,
+/// {
+///     // Create a new APA102 driver with 2 MHz data rate
+///     ClockedDelayDriver::<Apa102Led, _, _, _>::new(
+///         data_pin,
+///         clock_pin,
+///         delay,
+///         Megahertz::MHz(2)
+///     )
+/// }
+/// ```
 ///
 /// # Type Parameters
 ///
@@ -97,7 +89,7 @@ where
     }
 }
 
-impl<Led, Data, Clock, Delay> LedDriver for ClockedDelayDriver<Led, Data, Clock, Delay>
+impl<Led, Data, Clock, Delay> Driver for ClockedDelayDriver<Led, Data, Clock, Delay>
 where
     Led: ClockedLed<Word = u8>,
     Data: OutputPin,

--- a/blinksy/src/driver/clocked/delay.rs
+++ b/blinksy/src/driver/clocked/delay.rs
@@ -42,6 +42,7 @@ use crate::{
     color::{ColorCorrection, FromColor},
     time::{Megahertz, Nanoseconds},
 };
+
 use core::marker::PhantomData;
 use embedded_hal::{delay::DelayNs, digital::OutputPin};
 
@@ -65,7 +66,6 @@ where
 {
     /// Marker for the LED protocol type
     led: PhantomData<Led>,
-
     /// Writer implementation for the clocked protocol
     writer: ClockedDelayWriter<Data, Clock, Delay>,
 }
@@ -148,13 +148,10 @@ where
 {
     /// GPIO pin for data transmission
     data: Data,
-
     /// GPIO pin for clock signal
     clock: Clock,
-
     /// Delay provider for timing control
     delay: Delay,
-
     /// Half-cycle duration in nanoseconds
     t_half_cycle_ns: u32,
 }
@@ -203,7 +200,6 @@ where
 {
     /// Error from the data pin
     Data(Data::Error),
-
     /// Error from the clock pin
     Clock(Clock::Error),
 }
@@ -248,6 +244,7 @@ where
                 self.clock.set_low().map_err(ClockedDelayError::Clock)?;
             }
         }
+
         Ok(())
     }
 }

--- a/blinksy/src/driver/clocked/mod.rs
+++ b/blinksy/src/driver/clocked/mod.rs
@@ -64,6 +64,7 @@
 //!     }
 //! }
 //! ```
+
 use crate::color::{ColorCorrection, FromColor};
 
 use super::LedDriver;
@@ -218,7 +219,6 @@ pub trait ClockedLed {
 
         Self::reset(writer)?;
         Self::end(writer, pixel_count)?;
-
         Ok(())
     }
 }

--- a/blinksy/src/driver/clocked/mod.rs
+++ b/blinksy/src/driver/clocked/mod.rs
@@ -22,7 +22,7 @@
 //! ## Drivers
 //!
 //! - [`ClockedDelayDriver`]: Driver using GPIO bit-banging with a delay timer
-//! - [`ClockedSpiDriver`]: Driver using a hardware SPI peripheral
+//! - [`ClockedSpiDriver`]: (Recommended) Driver using a hardware SPI peripheral
 //!
 //! ## Example
 //!
@@ -67,7 +67,7 @@
 
 use crate::color::{ColorCorrection, FromColor};
 
-use super::LedDriver;
+use super::Driver;
 
 mod delay;
 mod spi;

--- a/blinksy/src/driver/clocked/spi.rs
+++ b/blinksy/src/driver/clocked/spi.rs
@@ -28,11 +28,12 @@
 use core::marker::PhantomData;
 use embedded_hal::spi::SpiBus;
 
-use super::{ClockedLed, ClockedWriter};
 use crate::{
     color::{ColorCorrection, FromColor},
     driver::LedDriver,
 };
+
+use super::{ClockedLed, ClockedWriter};
 
 /// Driver for clocked LEDs using a hardware SPI peripheral.
 ///

--- a/blinksy/src/driver/clocked/spi.rs
+++ b/blinksy/src/driver/clocked/spi.rs
@@ -21,7 +21,7 @@ use super::{ClockedLed, ClockedWriter};
 ///
 /// ```rust
 /// use embedded_hal::spi::SpiBus;
-/// use blinksy::{driver::ClockedSpiDriver, drivers::Apa102Led};
+/// use blinksy::{driver::ClockedSpiDriver, drivers::apa102::Apa102Led};
 ///
 /// fn setup_leds<S>(spi: S) -> ClockedSpiDriver<Apa102Led, S>
 /// where

--- a/blinksy/src/driver/clocked/spi.rs
+++ b/blinksy/src/driver/clocked/spi.rs
@@ -1,41 +1,36 @@
-//! # Clocked SPI-based LED Driver
-//!
-//! This module provides an implementation of the LedDriver trait for clocked LEDs
-//! using hardware SPI for data transmission. This allows for efficient, high-speed
-//! LED updates using dedicated SPI peripherals.
-//!
-//! ## Benefits of SPI-based implementation
-//!
-//! - Higher data rates than bit-banging
-//! - More efficient CPU usage
-//! - Better timing precision
-//!
-//! ## Usage
-//!
-//! ```rust
-//! use embedded_hal::spi::SpiBus;
-//! use blinksy::{driver::ClockedSpiDriver, drivers::Apa102Led};
-//!
-//! fn setup_leds<S>(spi: S) -> ClockedSpiDriver<Apa102Led, S>
-//! where
-//!     S: SpiBus<u8>,
-//! {
-//!     // Create a new APA102 driver using SPI
-//!     ClockedSpiDriver::<Apa102Led, _>::new(spi)
-//! }
-//! ```
-
 use core::marker::PhantomData;
 use embedded_hal::spi::SpiBus;
 
 use crate::{
     color::{ColorCorrection, FromColor},
-    driver::LedDriver,
+    driver::Driver,
 };
 
 use super::{ClockedLed, ClockedWriter};
 
 /// Driver for clocked LEDs using a hardware SPI peripheral.
+///
+/// - Separate GPIO pins for data and clock
+/// - A dedicated hardware SPI perhipheral for data transmission
+///   - Higher data rates than bit-banging
+///   - More efficient CPU usage
+///   - Better timing precision
+/// - Parameters defined by a ClockedLed implementation
+///
+/// ## Usage
+///
+/// ```rust
+/// use embedded_hal::spi::SpiBus;
+/// use blinksy::{driver::ClockedSpiDriver, drivers::Apa102Led};
+///
+/// fn setup_leds<S>(spi: S) -> ClockedSpiDriver<Apa102Led, S>
+/// where
+///     S: SpiBus<u8>,
+/// {
+///     // Create a new APA102 driver using SPI
+///     ClockedSpiDriver::<Apa102Led, _>::new(spi)
+/// }
+/// ```
 ///
 /// # Type Parameters
 ///
@@ -76,7 +71,7 @@ where
     }
 }
 
-impl<Led, Spi> LedDriver for ClockedSpiDriver<Led, Spi>
+impl<Led, Spi> Driver for ClockedSpiDriver<Led, Spi>
 where
     Led: ClockedLed<Word = u8>,
     Spi: SpiBus<u8>,

--- a/blinksy/src/driver/clockless/delay.rs
+++ b/blinksy/src/driver/clockless/delay.rs
@@ -23,7 +23,7 @@ use crate::{
 /// ```rust
 /// use embedded_hal::digital::OutputPin;
 /// use embedded_hal::delay::DelayNs;
-/// use blinksy::{driver::ClocklessDelayDriver, drivers::Ws2812Led};
+/// use blinksy::{driver::ClocklessDelayDriver, drivers::ws2812::Ws2812Led};
 ///
 /// fn setup_leds<P, D>(data_pin: P, delay: D) -> ClocklessDelayDriver<Ws2812Led, P, D>
 /// where

--- a/blinksy/src/driver/clockless/delay.rs
+++ b/blinksy/src/driver/clockless/delay.rs
@@ -1,45 +1,40 @@
-//! # Clockless Delay-based LED Driver
-//!
-//! This module provides an implementation of the LedDriver trait for clockless LEDs
-//! using GPIO bit-banging with a delay timer.
-//!
-//! The implementation uses:
-//!
-//! - A single GPIO output pin for data transmission
-//! - A delay provider for timing control
-//! - Timing parameters defined by a [`ClocklessLed`] implementation
-//!
-//! Note: This will not work unless your delay timer is able to handle microsecond
-//! precision, which most microcontrollers cannot do.
-//!
-//! ## Usage
-//!
-//! ```rust
-//! use embedded_hal::digital::OutputPin;
-//! use embedded_hal::delay::DelayNs;
-//! use blinksy::{driver::ClocklessDelayDriver, drivers::Ws2812Led};
-//!
-//! fn setup_leds<P, D>(data_pin: P, delay: D) -> ClocklessDelayDriver<Ws2812Led, P, D>
-//! where
-//!     P: OutputPin,
-//!     D: DelayNs,
-//! {
-//!     // Create a new WS2812 driver
-//!     ClocklessDelayDriver::<Ws2812Led, _, _>::new(data_pin, delay)
-//!         .expect("Failed to initialize LED driver")
-//! }
-//! ```
-
 use core::marker::PhantomData;
 use embedded_hal::{delay::DelayNs, digital::OutputPin};
 
 use super::ClocklessLed;
 use crate::{
     color::{ColorCorrection, FromColor, LinearSrgb},
-    driver::LedDriver,
+    driver::Driver,
 };
 
 /// Driver for clockless LEDs using GPIO bit-banging with a delay timer.
+///
+/// The implementation uses:
+///
+/// - A single GPIO output pin for data transmission
+/// - A delay provider for timing control
+/// - Timing parameters defined by a [`ClocklessLed`] implementation
+///
+/// Note: This will not work unless your delay timer is able to handle microsecond
+/// precision, which most microcontrollers cannot do.
+///
+/// ## Usage
+///
+/// ```rust
+/// use embedded_hal::digital::OutputPin;
+/// use embedded_hal::delay::DelayNs;
+/// use blinksy::{driver::ClocklessDelayDriver, drivers::Ws2812Led};
+///
+/// fn setup_leds<P, D>(data_pin: P, delay: D) -> ClocklessDelayDriver<Ws2812Led, P, D>
+/// where
+///     P: OutputPin,
+///     D: DelayNs,
+/// {
+///     // Create a new WS2812 driver
+///     ClocklessDelayDriver::<Ws2812Led, _, _>::new(data_pin, delay)
+///         .expect("Failed to initialize LED driver")
+/// }
+/// ```
 ///
 /// # Type Parameters
 ///
@@ -154,7 +149,7 @@ where
     }
 }
 
-impl<Led, Pin, Delay> LedDriver for ClocklessDelayDriver<Led, Pin, Delay>
+impl<Led, Pin, Delay> Driver for ClocklessDelayDriver<Led, Pin, Delay>
 where
     Led: ClocklessLed,
     Pin: OutputPin,

--- a/blinksy/src/driver/clockless/mod.rs
+++ b/blinksy/src/driver/clockless/mod.rs
@@ -52,6 +52,7 @@ use crate::color::LedChannels;
 use crate::time::Nanoseconds;
 
 mod delay;
+
 pub use self::delay::*;
 
 /// Trait that defines the timing parameters and protocol specifics for a clockless LED chipset.

--- a/blinksy/src/driver/mod.rs
+++ b/blinksy/src/driver/mod.rs
@@ -4,8 +4,6 @@
 //! It provides traits and implementations for interfacing with different
 //! LED chipsets and protocols.
 //!
-//! The main components are:
-//!
 //! - [`LedDriver`]: The core trait for all LED drivers
 //! - [`clocked`]: Implementations for clocked protocols (like APA102)
 //! - [`clockless`]: Implementations for clockless protocols (like WS2812)

--- a/blinksy/src/driver/mod.rs
+++ b/blinksy/src/driver/mod.rs
@@ -1,12 +1,10 @@
-//! # LED Driver Interface
+//! # Driver Interface
 //!
-//! This module defines the core abstractions for driving LED hardware.
-//! It provides traits and implementations for interfacing with different
-//! LED chipsets and protocols.
+//! A driver is what tells the LED hardware how to be the colors you want.
 //!
-//! - [`LedDriver`]: The core trait for all LED drivers
-//! - [`clocked`]: Implementations for clocked protocols (like APA102)
-//! - [`clockless`]: Implementations for clockless protocols (like WS2812)
+//! - [`Driver`] is the core trait for all drivers
+//! - The [`clocked`] module provides re-usable implementations for clocked (two-wire) protocols (like APA102)
+//! - The [`clockless`] module provides re-usable implementations for clockless (one-wire) protocols (like WS2812)
 
 use crate::color::{ColorCorrection, FromColor};
 
@@ -29,13 +27,13 @@ pub use clockless::*;
 /// # Example
 ///
 /// ```rust
-/// use blinksy::{color::{ColorCorrection, FromColor, LinearSrgb}, driver::LedDriver};
+/// use blinksy::{color::{ColorCorrection, FromColor, LinearSrgb}, driver::Driver};
 ///
 /// struct MyDriver {
 ///     // Implementation details
 /// }
 ///
-/// impl LedDriver for MyDriver {
+/// impl Driver for MyDriver {
 ///     type Error = ();
 ///     type Color = LinearSrgb;
 ///
@@ -49,7 +47,7 @@ pub use clockless::*;
 ///     }
 /// }
 /// ```
-pub trait LedDriver {
+pub trait Driver {
     /// The error type that may be returned by the driver.
     type Error;
 

--- a/blinksy/src/drivers/apa102.rs
+++ b/blinksy/src/drivers/apa102.rs
@@ -7,7 +7,7 @@
 //! # Drivers
 //!
 //! - [`Apa102Delay`]: Uses bit-banged GPIO
-//! - [`Apa102Spi`]: Uses a hardware SPI interface (Recommended)
+//! - [`Apa102Spi`]: (Recommended) Uses a hardware SPI interface
 //!
 //! ## Key Features
 //!

--- a/blinksy/src/drivers/apa102.rs
+++ b/blinksy/src/drivers/apa102.rs
@@ -4,17 +4,18 @@
 //! clocked SPI-like protocol. APA102 LEDs offer high refresh rates and precise
 //! brightness control.
 //!
-//! The module implements two driver types:
+//! # Drivers
 //!
-//! - [`Apa102Delay`]: Uses bit-banged GPIO with precise timing
-//! - [`Apa102Spi`]: Uses a hardware SPI interface for improved performance
+//! - [`Apa102Delay`]: Uses bit-banged GPIO
+//! - [`Apa102Spi`]: Uses a hardware SPI interface (Recommended)
 //!
 //! ## Key Features
 //!
-//! - 8-bit global brightness control (0-255)
-//! - 8-bit per-channel color resolution
+//! - Two-wire protocol (data and clock)
+//! - 24-bit color (8 bits per channel)
+//! - 5-bit global brightness control (0-31)
+//! - Bring-your-own clock rate (unlike WS2812)
 //! - Supports high update rates
-//! - No strict timing requirements (unlike WS2812)
 //!
 //! ## Protocol Details
 //!
@@ -79,23 +80,24 @@ impl ClockedLed for Apa102Led {
         brightness: f32,
         correction: ColorCorrection,
     ) -> Result<(), Writer::Error> {
+        // Convert color to linear sRGB
         let linear = LinearSrgb::from_color(color);
         let (red, green, blue) = (linear.red, linear.green, linear.blue);
 
-        // First color correct the linear RGB
+        // Color correct
         let red = red * correction.red;
         let green = green * correction.red;
         let blue = blue * correction.red;
 
-        // Then, convert to u16's
+        // Convert color components to u16's
         let (red_u16, green_u16, blue_u16) = (
             Component::from_normalized_f32(red),
             Component::from_normalized_f32(green),
             Component::from_normalized_f32(blue),
         );
 
+        // Continue with APA102HD algorithm from FastLED
         let brightness: u8 = Component::from_normalized_f32(brightness);
-
         let ((red_u8, green_u8, blue_u8), brightness) =
             five_bit_bitshift(red_u16, green_u16, blue_u16, brightness);
 
@@ -202,6 +204,7 @@ fn brightness_bitshifter8(brightness_src: &mut u8, brightness_dst: &mut u8, max_
         if curr & 0b1000_0000 != 0 {
             break;
         }
+
         curr <<= 1;
         src >>= 1;
         shifts += 1;
@@ -239,8 +242,8 @@ fn brightness_bitshifter16(
         overflow_mask >>= 1;
         overflow_mask |= 0b1000_0000_0000_0000;
     }
-
     let underflow_mask: u8 = 0x1;
+
     let mut curr = *brightness_dst;
     let mut shifts = 0;
 
@@ -251,6 +254,7 @@ fn brightness_bitshifter16(
         if curr & overflow_mask != 0 {
             break;
         }
+
         curr <<= steps;
         src >>= 1;
         shifts += 1;

--- a/blinksy/src/drivers/mod.rs
+++ b/blinksy/src/drivers/mod.rs
@@ -1,7 +1,7 @@
 //! # LED Driver Implementations
+//!
+//! - [`apa102`]: APA102 (DotStar) LEDs
+//! - [`ws2812`]: WS2812 (NeoPixel) LEDs
 
-mod apa102;
-mod ws2812;
-
-pub use self::apa102::*;
-pub use self::ws2812::*;
+pub mod apa102;
+pub mod ws2812;

--- a/blinksy/src/drivers/ws2812.rs
+++ b/blinksy/src/drivers/ws2812.rs
@@ -4,12 +4,17 @@
 //! single-wire, timing-sensitive protocol. WS2812 LEDs are widely used due to their
 //! simplicity and low cost.
 //!
+//! # Drivers
+//!
+//! - [`Ws2812Delay`]: Uses bit-banged GPIO
+//! - [`blinksy-esp::drivers::Ws2812Rmt`]: On ESP devices, uses RMT peripheral
+//!
 //! ## Key Features
 //!
 //! - Single-wire protocol (data only, no clock)
 //! - 24-bit color (8 bits per channel)
-//! - Non-standard color order (GRB by default)
 //! - Timing-sensitive protocol
+//! - Fixed update rate: 30μs per pixel
 //!
 //! ## Protocol Details
 //!
@@ -22,6 +27,8 @@
 //! (References: [Datasheet](https://cdn-shop.adafruit.com/datasheets/WS2812B.pdf))
 //!
 //! Each LED receives 24 bits (RGB) and then passes subsequent data to the next LED in the chain.
+//!
+//! [`blinksy-esp::drivers::
 
 use fugit::NanosDurationU32 as Nanoseconds;
 
@@ -62,4 +69,7 @@ impl ClocklessLed for Ws2812Led {
 ///
 /// * `Pin` - The data pin type
 /// * `Delay` - The delay implementation type
+///
+/// Note: This will not work unless your delay timer is able to handle microsecond
+/// precision, which most microcontrollers cannot do.
 pub type Ws2812Delay<Pin, Delay> = ClocklessDelayDriver<Ws2812Led, Pin, Delay>;

--- a/blinksy/src/drivers/ws2812.rs
+++ b/blinksy/src/drivers/ws2812.rs
@@ -7,7 +7,7 @@
 //! # Drivers
 //!
 //! - [`Ws2812Delay`]: Uses bit-banged GPIO
-//! - [`blinksy-esp::drivers::Ws2812Rmt`]: On ESP devices, uses RMT peripheral
+//! - [`blinksy-esp::Ws2812Rmt`]: On ESP devices, uses RMT peripheral
 //!
 //! ## Key Features
 //!
@@ -28,7 +28,7 @@
 //!
 //! Each LED receives 24 bits (RGB) and then passes subsequent data to the next LED in the chain.
 //!
-//! [`blinksy-esp::drivers::Ws2812Rmt`]: https://docs.rs/blinksy-esp/latest/blinksy-esp/drivers/type.Ws2812Rmt.html
+//! [`blinksy-esp::Ws2812Rmt`]: https://docs.rs/blinksy-esp/latest/blinksy-esp/type.Ws2812Rmt.html
 
 use fugit::NanosDurationU32 as Nanoseconds;
 

--- a/blinksy/src/drivers/ws2812.rs
+++ b/blinksy/src/drivers/ws2812.rs
@@ -28,7 +28,7 @@
 //!
 //! Each LED receives 24 bits (RGB) and then passes subsequent data to the next LED in the chain.
 //!
-//! [`blinksy-esp::drivers::
+//! [`blinksy-esp::drivers::Ws2812Rmt`]: https://docs.rs/blinksy-esp/latest/blinksy-esp/drivers/type.Ws2812Rmt.html
 
 use fugit::NanosDurationU32 as Nanoseconds;
 

--- a/blinksy/src/layout.rs
+++ b/blinksy/src/layout.rs
@@ -1,6 +1,7 @@
-//! # LED Layout Abstractions
+//! # LED Layouts
 //!
-//! This module provides traits and types for defining LED arrangements in 1D, 2D, and 3D space.
+//! Layouts define the physical or logical positions of LEDs in your setup, as arrangements
+//! in 1D, 2D, and 3D space.
 //!
 //! The module supports various layout types through dedicated traits:
 //! - [`Layout1d`]: For linear LED strips
@@ -61,7 +62,6 @@ pub trait Layout1d {
         } else {
             0.0
         };
-
         (0..Self::PIXEL_COUNT).map(move |index| -1.0 + (index as f32 * spacing))
     }
 }
@@ -85,6 +85,7 @@ pub trait Layout1d {
 macro_rules! layout1d {
     ($name:ident, $pixel_count:expr) => {
         struct $name;
+
         impl $crate::layout::Layout1d for $name {
             const PIXEL_COUNT: usize = $pixel_count;
         }
@@ -402,10 +403,12 @@ pub trait Layout2d {
 /// ```
 #[macro_export]
 macro_rules! layout2d {
-    ($name:ident, [$($shape:expr),*$(,)?]) => {
+    ($name:ident, [$($shape:expr),* $(,)?]) => {
         struct $name;
+
         impl $crate::layout::Layout2d for $name {
             const PIXEL_COUNT: usize = 0 $(+ $shape.pixel_count())*;
+
             fn shapes() -> impl Iterator<Item = $crate::layout::Shape2d> {
                 [$($shape),*].into_iter()
             }

--- a/blinksy/src/layout.rs
+++ b/blinksy/src/layout.rs
@@ -1,16 +1,14 @@
 //! # LED Layouts
 //!
-//! Layouts define the physical or logical positions of LEDs in your setup, as arrangements
-//! in 1D, 2D, and 3D space.
+//! A layout defines the physical or logical positions of the LEDs in your setup, as
+//! arrangements in 1D, 2D, and 3D space.
 //!
-//! The module supports various layout types through dedicated traits:
-//! - [`Layout1d`]: For linear LED strips
-//! - [`Layout2d`]: For 2D layouts like matrices, grids, and complex shapes
-//! - (Future) Layout3d: For 3D arrangements
+//! - For 1D, use [`layout1d!`] to define a type that implements [`Layout1d`]
+//! - For 2D, use [`layout2d!`] to define a type that implements [`Layout2d`]
 //!
 //! ## 1D Layouts
 //!
-//! For simple linear arrangements, use the [`layout1d!`](crate::layout1d!) macro:
+//! For simple linear arrangements, use the [`layout1d!`] macro:
 //!
 //! ```rust
 //! use blinksy::layout1d;
@@ -21,7 +19,7 @@
 //!
 //! ## 2D Layouts
 //!
-//! For 2D layouts, use the [`layout2d!`](crate::layout2d!) macro with one or more [`Shape2d`] definitions:
+//! For 2D layouts, use the [`layout2d!`] macro with one or more [`Shape2d`] definitions:
 //!
 //! ```rust
 //! use blinksy::{layout2d, layout::Shape2d, layout::Vec2};
@@ -39,6 +37,9 @@
 //!     }]
 //! );
 //! ```
+//!
+//! [`layout1d!`]: crate::layout1d!
+//! [`layout2d!`]: crate::layout2d!
 
 use core::{
     iter::{once, Once},
@@ -51,6 +52,8 @@ use num_traits::FromPrimitive;
 /// Trait for one-dimensional LED layouts.
 ///
 /// Implementors of this trait represent a linear arrangement of LEDs.
+///
+/// Use [`layout1d!`](crate::layout1d) to define a type that implements [`Layout1d`].
 pub trait Layout1d {
     /// The total number of LEDs in this layout.
     const PIXEL_COUNT: usize;
@@ -66,12 +69,16 @@ pub trait Layout1d {
     }
 }
 
-/// Creates a one-dimensional LED layout.
+/// Creates a one-dimensional LED layout from a pixel count.
 ///
 /// # Arguments
 ///
 /// * `$name` - The name of the layout type to create
 /// * `$pixel_count` - The number of LEDs in the layout
+///
+/// # Output
+///
+/// Macro output will be a type definition that implements [`Layout1d`].
 ///
 /// # Example
 ///
@@ -364,6 +371,8 @@ impl Shape2d {
 /// Trait for two-dimensional LED layouts.
 ///
 /// Implementors of this trait represent a 2D arrangement of LEDs using one or more shapes.
+///
+/// Use [`layout2d!`](crate::layout2d) to define a type that implements [`Layout2d`].
 pub trait Layout2d {
     /// The total number of LEDs in this layout.
     const PIXEL_COUNT: usize;
@@ -383,6 +392,10 @@ pub trait Layout2d {
 ///
 /// * `$name` - The name of the layout type to create
 /// * `[$($shape:expr),*]` - A list of Shape2d instances defining the layout
+///
+/// # Output
+///
+/// Macro output will be a type definition that implements [`Layout2d`].
 ///
 /// # Example
 ///
@@ -415,7 +428,3 @@ macro_rules! layout2d {
         }
     };
 }
-
-/// Placeholder for future 3D shape support.
-#[derive(Debug, Clone)]
-pub enum Shape3d {}

--- a/blinksy/src/lib.rs
+++ b/blinksy/src/lib.rs
@@ -30,26 +30,14 @@
 //! - **Desktop Simulation:** Run a simulation of a layout and pattern on your computer to experiment with ideas.
 //! - (TODO) **Audio-Reactive**: Easily integrate audio reactivity into visual patterns.
 //!
-//! ## Architecture
-//!
-//! The library is organized into several modules:
-//!
-//! - [`color`]: Color types and utilities
-//! - [`control`]: Control system
-//! - [`dimension`]: Dimension type-level markers
-//! - [`driver`]: LED driver interface
-//! - [`drivers`]: LED driver implementations
-//! - [`layout`]: LED layout abstractions
-//! - [`pattern`]: Pattern abstraction
-//! - [`patterns`]: Pattern implementations
-//! - [`time`]: Timing utilities
-//!
 //! ## Quick Start
+//!
+//! To get started, see [control].
 //!
 //! ### 1D Strip with Rainbow Pattern
 //!
 //! ```rust,ignore
-//! use blinksy::{ControlBuilder, layout1d, patterns::{Rainbow, RainbowParams}};
+//! use blinksy::{ControlBuilder, layout1d, patterns::rainbow::{Rainbow, RainbowParams}};
 //!
 //! // Define a 1D layout with 60 LEDs
 //! layout1d!(Layout, 60);
@@ -74,7 +62,7 @@
 //!     ControlBuilder,
 //!     layout::{Shape2d, Vec2},
 //!     layout2d,
-//!     patterns::{noise_fns, Noise2d, NoiseParams},
+//!     patterns::noise::{noise_fns, Noise2d, NoiseParams},
 //! };
 //!
 //! layout2d!(

--- a/blinksy/src/lib.rs
+++ b/blinksy/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! # Blinksy
 //!
-//! Blinksy is a no-std, no-alloc LED control library designed for 1D, 2D, and 3D (audio-reactive)
+//! Blinksy is a no-std, no-alloc LED control library designed for 1D, 2D, and 3D
 //! LED setups, inspired by [FastLED](https://fastled.io/) and [WLED](https://kno.wled.ge/).
 //!
 //! ## How Blinksy works

--- a/blinksy/src/lib.rs
+++ b/blinksy/src/lib.rs
@@ -110,7 +110,6 @@ pub mod layout;
 pub mod pattern;
 pub mod patterns;
 pub mod time;
-
 mod util;
 
 pub use self::control::*;

--- a/blinksy/src/pattern.rs
+++ b/blinksy/src/pattern.rs
@@ -1,24 +1,25 @@
 //! # Pattern Interface
 //!
-//! This module defines the [`Pattern`] trait, which is the core abstraction for
-//! visual effects in Blinksy. Patterns generate colors for LEDs based on time and position.
+//! A pattern, most similar to [a WLED effect], generates colors for LEDs based on time and
+//! position.
 //!
-//! A pattern takes:
+//! A [`Pattern`] takes:
 //!
+//! - The layout of the LEDs (through its type parameters)
 //! - Configuration parameters during initialization
 //! - The current time during each update cycle
-//! - Information about the layout it's operating on (through its type parameters)
 //!
-//! It produces:
+//! And produces:
 //!
 //! - A sequence of colors for each LED in the layout
 //!
-//! Patterns are generic over both the dimension they operate in and the specific layout
-//! type, allowing compile-time enforcement of dimensional compatibility.
+//! For the library of built-in patterns, see [patterns](crate::patterns).
+//!
+//! [a WLED effect]: https://kno.wled.ge/features/effects/
 
 use crate::dimension::LayoutForDim;
 
-/// Trait for creating visual patterns on LED layouts.
+/// Trait for creating visual effects on LED layouts.
 ///
 /// Patterns generate colors for each LED in a layout based on time and position.
 /// They are generic over both the dimension they operate in and the specific layout type.

--- a/blinksy/src/pattern.rs
+++ b/blinksy/src/pattern.rs
@@ -3,7 +3,7 @@
 //! A pattern, most similar to [a WLED effect], generates colors for LEDs based on time and
 //! position.
 //!
-//! A [`Pattern`] takes:
+//! A [`Pattern`] receives:
 //!
 //! - The layout of the LEDs (through its type parameters)
 //! - Configuration parameters during initialization

--- a/blinksy/src/patterns/mod.rs
+++ b/blinksy/src/patterns/mod.rs
@@ -1,7 +1,8 @@
 //! # Pattern Implementations
+//!
+//! This is the library of built-in patterns.
+//!
+//! [Make an issue](https://github.com/ahdinosaur/blinksy/issues) if you want help to port a pattern from FastLED / WLED to Rust!
 
-mod noise;
-mod rainbow;
-
-pub use noise::*;
-pub use rainbow::*;
+pub mod noise;
+pub mod rainbow;

--- a/blinksy/src/patterns/noise.rs
+++ b/blinksy/src/patterns/noise.rs
@@ -26,7 +26,7 @@
 //!     ControlBuilder,
 //!     layout2d,
 //!     layout::{Shape2d, Vec2},
-//!     patterns::{Noise2d, noise_fns, NoiseParams}
+//!     patterns::noise::{Noise2d, noise_fns, NoiseParams}
 //! };
 //!
 //! // Define a 2D layout

--- a/blinksy/src/patterns/noise.rs
+++ b/blinksy/src/patterns/noise.rs
@@ -1,7 +1,23 @@
 //! # Noise Patterns
 //!
-//! This module provides a noise-based effect pattern that creates smooth, organic, and flowing
-//! color transitions across the LED layout.
+//! The noise pattern creates flowing animations based on a noise function.
+//!
+//! # What is a noise function?
+//!
+//! A noise function is given a position in 1d, 2d, 3d, or 4d space and returns
+//! a random value between -1.0 and 1.0, where values between nearbly positions are
+//! smoothly interpolated.
+//!
+//! For example, a common use of noise functions is to procedurally generate terrain.
+//! You could give a 2d noise function an (x, y) position and use the resulting value
+//! as an elevation.
+//!
+//! In our case, we will use noise functions to generate `hue` and `value` for [Okhsv]
+//! colors. To animate through time, rather than adding time to our position, we will
+//! input the time to the noise function as an additonal dimension. So a 1d layout will
+//! use a 2d noise function, a 2d layout a 3d noise function, and so on.
+//!
+//! This pattern is the same concept as what you see on [mikey.nz](https://mikey.nz/).
 //!
 //! ## Example
 //!
@@ -36,6 +52,9 @@
 //!     .with_driver(/* your driver */)
 //!     .build();
 //! ```
+//!
+//! [`Okhsv`]: crate::color::Okhsv
+//! [mikey.nz]: https://mikey.nz
 
 use noise::{NoiseFn, Seedable};
 
@@ -72,7 +91,7 @@ impl Default for NoiseParams {
 
 /// One-dimensional noise pattern implementation.
 ///
-/// Creates flowing patterns based on a 2D noise function, using
+/// Creates flowing animations based on a 2D noise function, using
 /// time and the 1D position for the input coordinates.
 #[derive(Debug)]
 pub struct Noise1d<Noise>
@@ -134,7 +153,7 @@ where
 
 /// Two-dimensional noise pattern implementation.
 ///
-/// Creates flowing patterns based on a 3D noise function, using
+/// Creates flowing animations based on a 3D noise function, using
 /// time and the 2D position for the input coordinates.
 #[derive(Debug)]
 pub struct Noise2d<Noise>

--- a/blinksy/src/patterns/noise.rs
+++ b/blinksy/src/patterns/noise.rs
@@ -1,15 +1,7 @@
 //! # Noise Patterns
 //!
-//! This module provides noise-based visual effects that use noise functions to create
-//! organic, flowing patterns. Noise patterns are useful for creating fire, clouds, water,
-//! and other natural-looking animations.
-//!
-//! ## Features
-//!
-//! - Multiple noise function options (Perlin, Simplex, OpenSimplex)
-//! - Configurable animation speed and scale
-//! - 1D and 2D variants for different layout types
-//! - Creates flowing, organic patterns
+//! This module provides a noise-based effect pattern that creates smooth, organic, and flowing
+//! color transitions across the LED layout.
 //!
 //! ## Example
 //!
@@ -64,7 +56,6 @@ pub mod noise_fns {
 pub struct NoiseParams {
     /// Controls the speed of animation (higher = faster)
     pub time_scalar: f64,
-
     /// Controls the spatial scale of the noise (higher = more compressed)
     pub position_scalar: f64,
 }
@@ -90,10 +81,8 @@ where
 {
     /// The noise function used to get hue
     hue_noise: Noise,
-
     /// The noise function used to get value
     value_noise: Noise,
-
     /// Configuration parameters
     params: NoiseParams,
 }
@@ -125,6 +114,7 @@ where
             value_noise,
             params,
         } = self;
+
         let NoiseParams {
             time_scalar,
             position_scalar,
@@ -153,10 +143,8 @@ where
 {
     /// The noise function used to get hue
     hue_noise: Noise,
-
     /// The noise function used to get value
     value_noise: Noise,
-
     /// Configuration parameters
     params: NoiseParams,
 }
@@ -188,6 +176,7 @@ where
             value_noise,
             params,
         } = self;
+
         let NoiseParams {
             time_scalar,
             position_scalar,

--- a/blinksy/src/patterns/rainbow.rs
+++ b/blinksy/src/patterns/rainbow.rs
@@ -1,15 +1,8 @@
 //! # Rainbow Pattern
 //!
 //! This module provides a rainbow effect pattern that creates smooth color transitions
-//! across the LED layout. The colors flow through the full HSV spectrum, creating a
+//! across the LED layout. The colors flow through the full Okhsv spectrum, creating a
 //! classic rainbow visual.
-//!
-//! ## Features
-//!
-//! - Smooth transitions through the full color spectrum
-//! - Configurable animation speed
-//! - Adjustable spatial density (how compressed the rainbow appears)
-//! - Works with both 1D and 2D layouts
 //!
 //! ## Example
 //!
@@ -46,7 +39,6 @@ use crate::{
 pub struct RainbowParams {
     /// Controls the speed of the animation (higher = faster)
     pub time_scalar: f32,
-
     /// Controls the spatial density of the rainbow (higher = more compressed)
     pub position_scalar: f32,
 }

--- a/blinksy/src/patterns/rainbow.rs
+++ b/blinksy/src/patterns/rainbow.rs
@@ -1,8 +1,8 @@
 //! # Rainbow Pattern
 //!
-//! This module provides a rainbow effect pattern that creates smooth color transitions
-//! across the LED layout. The colors flow through the full Okhsv spectrum, creating a
-//! classic rainbow visual.
+//! The rainbow pattern creates smooth color transitions across the LED layout.
+//! The colors flow through the full Okhsv spectrum, creating a classic rainbow
+//! visual.
 //!
 //! ## Example
 //!

--- a/blinksy/src/patterns/rainbow.rs
+++ b/blinksy/src/patterns/rainbow.rs
@@ -10,7 +10,7 @@
 //! use blinksy::{
 //!     ControlBuilder,
 //!     layout1d,
-//!     patterns::{Rainbow, RainbowParams}
+//!     patterns::rainbow::{Rainbow, RainbowParams}
 //! };
 //!
 //! // Define a 1D layout

--- a/blinksy/src/time.rs
+++ b/blinksy/src/time.rs
@@ -1,18 +1,11 @@
-//! # Timing Utilities
+//! # Time Library
 //!
-//! This module provides time-related types for precise timing control in LED animations.
-//! It re-exports types from the `fugit` crate for convenient time handling in a no-std environment.
+//! Types to represent time are provided by the [`fugit`] crate:
 //!
-//! The primary types are:
+//! - [`Megahertz`]: For specifying clock rates in MHz
+//! - [`Nanoseconds`]: For specifying timing durations in nanoseconds
 //!
-//! - [`Megahertz`]: For specifying clock frequencies in MHz
-//! - [`Nanoseconds`]: For precise timing durations in nanoseconds
-//!
-//! These types are used throughout the library for:
-//!
-//! - Configuring driver timing parameters
-//! - Controlling animation speed and transitions
-//! - Managing timing-sensitive LED protocols
+//! [`fugit`]: https://docs.rs/fugit
 
 /// Represents a frequency in megahertz (MHz).
 ///

--- a/blinksy/src/util/component.rs
+++ b/blinksy/src/util/component.rs
@@ -1,5 +1,14 @@
+/// Blinksy represents values, such as an LED color component, either as:
+///
+/// - a normalized `f32` between 0.0 and 1.0 (inclusive)
+/// - an integer between that type's min and max
+///
+/// This trait enables conversions between these two cases.
 pub trait Component: Copy {
+    /// Converts the component value to a normalized f32 in range [0.0, 1.0].
     fn to_normalized_f32(self) -> f32;
+
+    /// Creates a component value from a normalized f32 in range [0.0, 1.0].
     fn from_normalized_f32(value: f32) -> Self;
 }
 
@@ -9,6 +18,7 @@ macro_rules! impl_component_for_uint {
             fn to_normalized_f32(self) -> f32 {
                 self as f32 / ($T::MAX as f32)
             }
+
             fn from_normalized_f32(value: f32) -> Self {
                 (value * ($T::MAX as f32)) as $T
             }
@@ -24,6 +34,7 @@ impl Component for f32 {
     fn to_normalized_f32(self) -> f32 {
         self.clamp(0., 1.)
     }
+
     fn from_normalized_f32(value: f32) -> f32 {
         value
     }

--- a/esp/blinksy-esp/src/lib.rs
+++ b/esp/blinksy-esp/src/lib.rs
@@ -44,26 +44,17 @@
 //! }
 //! ```
 
-mod rmt;
+pub mod rmt;
 
-/// RMT-based LED driver
-pub mod driver {
-    pub use crate::rmt::*;
-}
+use crate::rmt::ClocklessRmtDriver;
+use blinksy::drivers::ws2812::Ws2812Led;
 
-/// Concrete driver implementations
-pub mod drivers {
-    use crate::rmt::ClocklessRmtDriver;
-    use blinksy::drivers::Ws2812Led;
-
-    /// WS2812 LED driver using the ESP32 RMT peripheral.
-    ///
-    /// This driver provides efficient, hardware-accelerated control of WS2812 LEDs.
-    ///
-    /// # Type Parameters
-    ///
-    /// * `Tx` - RMT transmit channel type
-    /// * `BUFFER_SIZE` - Size of the RMT buffer
-    pub type Ws2812Rmt<Tx, const BUFFER_SIZE: usize> =
-        ClocklessRmtDriver<Ws2812Led, Tx, BUFFER_SIZE>;
-}
+/// WS2812 LED driver using the ESP32 RMT peripheral.
+///
+/// This driver provides efficient, hardware-accelerated control of WS2812 LEDs.
+///
+/// # Type Parameters
+///
+/// * `Tx` - RMT transmit channel type
+/// * `BUFFER_SIZE` - Size of the RMT buffer
+pub type Ws2812Rmt<Tx, const BUFFER_SIZE: usize> = ClocklessRmtDriver<Ws2812Led, Tx, BUFFER_SIZE>;

--- a/esp/blinksy-esp/src/rmt.rs
+++ b/esp/blinksy-esp/src/rmt.rs
@@ -17,7 +17,7 @@
 
 use blinksy::{
     color::{ColorCorrection, FromColor, LedColor, LinearSrgb},
-    driver::{clockless::ClocklessLed, LedDriver},
+    driver::{clockless::ClocklessLed, Driver},
 };
 use core::{fmt::Debug, marker::PhantomData, slice::IterMut};
 use esp_hal::{
@@ -245,10 +245,10 @@ where
     }
 }
 
-/// Implementation of LedDriver trait for ClocklessRmtDriver.
+/// Implementation of Driver trait for ClocklessRmtDriver.
 ///
 /// This allows the RMT driver to be used with the Blinksy control system.
-impl<Led, Tx, const BUFFER_SIZE: usize> LedDriver for ClocklessRmtDriver<Led, Tx, BUFFER_SIZE>
+impl<Led, Tx, const BUFFER_SIZE: usize> Driver for ClocklessRmtDriver<Led, Tx, BUFFER_SIZE>
 where
     Led: ClocklessLed,
     Tx: TxChannel,

--- a/esp/blinksy-esp/src/rmt.rs
+++ b/esp/blinksy-esp/src/rmt.rs
@@ -8,8 +8,6 @@
 //!
 //! - Hardware-accelerated LED control
 //! - Precise timing for WS2812 and similar protocols
-//! - Compatible with the Blinksy LedDriver trait
-//! - Configurable buffer size for different LED strip lengths
 //!
 //! ## Technical Details
 //!

--- a/esp/gledopto/README.md
+++ b/esp/gledopto/README.md
@@ -32,7 +32,7 @@ https://github.com/user-attachments/assets/1c1cf3a2-f65c-4152-b444-29834ac749ee
 use blinksy::{
     layout::{Shape2d, Vec2},
     layout2d,
-    patterns::{noise_fns, Noise2d, NoiseParams},
+    patterns::noise::{noise_fns, Noise2d, NoiseParams},
     ControlBuilder,
 };
 use gledopto::{apa102, board, elapsed, main};
@@ -80,7 +80,7 @@ https://github.com/user-attachments/assets/703fe31d-e7ca-4e08-ae2b-7829c0d4d52e
 use blinksy::{
     layout::Layout1d,
     layout1d,
-    patterns::{Rainbow, RainbowParams},
+    patterns::rainbow::{Rainbow, RainbowParams},
     ControlBuilder,
 };
 use gledopto::{board, elapsed, main, ws2812};

--- a/esp/gledopto/examples/apa102-grid.rs
+++ b/esp/gledopto/examples/apa102-grid.rs
@@ -4,7 +4,7 @@
 use blinksy::{
     layout::{Shape2d, Vec2},
     layout2d,
-    patterns::{noise_fns, Noise2d, NoiseParams},
+    patterns::noise::{noise_fns, Noise2d, NoiseParams},
     ControlBuilder,
 };
 use gledopto::{apa102, board, elapsed, main};

--- a/esp/gledopto/examples/ws2812-strip.rs
+++ b/esp/gledopto/examples/ws2812-strip.rs
@@ -4,7 +4,7 @@
 use blinksy::{
     layout::Layout1d,
     layout1d,
-    patterns::{Rainbow, RainbowParams},
+    patterns::rainbow::{Rainbow, RainbowParams},
     ControlBuilder,
 };
 use gledopto::{board, elapsed, main, ws2812};

--- a/esp/gledopto/src/lib.rs
+++ b/esp/gledopto/src/lib.rs
@@ -140,7 +140,7 @@ macro_rules! apa102 {
         .with_sck(clock_pin)
         .with_mosi(data_pin);
 
-        $crate::blinksy::drivers::Apa102Spi::new(spi)
+        $crate::blinksy::drivers::apa102::Apa102Spi::new(spi)
     }};
 }
 
@@ -162,11 +162,11 @@ macro_rules! ws2812 {
         let rmt = $crate::hal::rmt::Rmt::new($peripherals.RMT, freq).unwrap();
 
         const CHANNEL_COUNT: usize = <
-                        $crate::blinksy::drivers::Ws2812Led as $crate::blinksy::driver::ClocklessLed
+                        $crate::blinksy::drivers::ws2812::Ws2812Led as $crate::blinksy::driver::ClocklessLed
                     >::LED_CHANNELS.channel_count();
 
         let rmt_buffer = $crate::blinksy_esp::create_rmt_buffer!($num_leds, CHANNEL_COUNT);
 
-        $crate::blinksy_esp::drivers::Ws2812Rmt::new(rmt.channel0, led_pin, rmt_buffer)
+        $crate::blinksy_esp::Ws2812Rmt::new(rmt.channel0, led_pin, rmt_buffer)
     }};
 }

--- a/esp/gledopto/src/lib.rs
+++ b/esp/gledopto/src/lib.rs
@@ -21,7 +21,7 @@
 //! use blinksy::{
 //!     layout::Layout1d,
 //!     layout1d,
-//!     patterns::{Rainbow, RainbowParams},
+//!     patterns::rainbow::{Rainbow, RainbowParams},
 //!     ControlBuilder,
 //! };
 //! use gledopto::{board, elapsed, main, ws2812};


### PR DESCRIPTION
- Also reorganize some modules:
  - Keep patterns in sub-modules (i.e. rainbow, noise)
  - Keep drivers in sub-modules for each chipset (i.e. apa102, ws2812)