### PR TITLE
More esp and gledopto docs

### DIFF
--- a/esp/Cargo.lock
+++ b/esp/Cargo.lock
@@ -57,7 +57,7 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "blinksy"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "defmt 0.3.100",
  "embedded-hal 1.0.0",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "blinksy-esp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "blinksy",
  "defmt 0.3.100",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "gledopto"
-version = "0.2.3"
+version = "0.3.1"
 dependencies = [
  "blinksy",
  "blinksy-esp",

--- a/esp/blinksy-esp/src/lib.rs
+++ b/esp/blinksy-esp/src/lib.rs
@@ -2,16 +2,14 @@
 
 //! # ESP32 Blinksy Extensions
 //!
-//! This crate provides ESP32-specific extensions for the Blinksy LED control library.
-//! It adapts the generic Blinksy abstractions to the specific hardware capabilities
-//! of the ESP32, particularly focusing on efficient LED driving using the RMT
-//! (Remote Control Module) peripheral.
+//! ESP32-specific extensions for the [Blinksy][blinksy] LED control library using [`esp-hal`][esp_hal].
 //!
 //! ## Features
 //!
-//! - ESP32 RMT-based driver for clockless (e.g. WS2812) LEDs
-//! - Hardware-accelerated LED driving for improved performance
-//! - Convenient API matching the core Blinksy interface
+//! - ESP-specific driver for clockless (e.g. WS2812) LEDs, using [RMT (Remote Control Module)][RMT] peripheral
+//! - ESP-specific elapsed time helper
+//!
+//! [RMT]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/rmt.html
 //!
 //! ## Usage
 //!

--- a/esp/blinksy-esp/src/lib.rs
+++ b/esp/blinksy-esp/src/lib.rs
@@ -17,29 +17,23 @@
 //! #![no_std]
 //! #![no_main]
 //!
-//! // Required for panic handling
-//! use esp_backtrace as _;
-//!
 //! use esp_hal as hal;
 //!
 //! use blinksy::{
+//!     driver::ClocklessLed,
+//!     drivers::ws2812::Ws2812Led,
+//!     layout::Layout1d,
 //!     layout1d,
 //!     patterns::rainbow::{Rainbow, RainbowParams},
 //!     ControlBuilder,
-//!     driver::ClocklessLed,
-//!     drivers::ws2812::Ws2812Led,
 //! };
-//! use blinksy_esp::{
-//!     create_rmt_buffer,
-//!     time::elapsed,
-//!     Ws2812Rmt,
-//! };
+//! use blinksy_esp::{create_rmt_buffer, time::elapsed, Ws2812Rmt};
 //!
 //! #[hal::main]
 //! fn main() -> ! {
 //!     let cpu_clock = hal::clock::CpuClock::max();
 //!     let config = hal::Config::default().with_cpu_clock(cpu_clock);
-//!     let p = hal::init(config)
+//!     let p = hal::init(config);
 //!
 //!     // Define the LED layout (1D strip of 300 pixels)
 //!     layout1d!(Layout, 60 * 5);
@@ -52,20 +46,18 @@
 //!         let data_pin = p.GPIO16;
 //!
 //!         // RMT peripheral frequency, typically 80MHz for WS2812 on ESP32.
-//!         let rmt_clk_freq = Rate::from_mhz(80);
+//!         let rmt_clk_freq = hal::time::Rate::from_mhz(80);
 //!
 //!         // Initialize RMT peripheral.
-//!         let rmt = Rmt::new(p.RMT, rmt_clk_freq).unwrap();
+//!         let rmt = hal::rmt::Rmt::new(p.RMT, rmt_clk_freq).unwrap();
 //!         let rmt_channel = rmt.channel0;
 //!
 //!         // Create RMT buffer
 //!         const NUM_LEDS: usize = Layout::PIXEL_COUNT;
-//!         const CHANNELS_PER_LED: usize =
-//!             <Ws2812Led as ClocklessLed>::LED_CHANNELS.channel_count(); // Usually 3 (RGB)
+//!         const CHANNELS_PER_LED: usize = <Ws2812Led as ClocklessLed>::LED_CHANNELS.channel_count(); // Usually 3 (RGB)
 //!         let rmt_buffer = create_rmt_buffer!(NUM_LEDS, CHANNELS_PER_LED);
 //!
 //!         Ws2812Rmt::new(rmt_channel, data_pin, rmt_buffer)
-//!             .expect("Failed to create WS2812 RMT driver")
 //!     };
 //!
 //!     // Build the Blinky controller

--- a/esp/blinksy-esp/src/time.rs
+++ b/esp/blinksy-esp/src/time.rs
@@ -1,0 +1,24 @@
+//! # Time Utilities
+//!
+//! This module helps you with time on an ESP microcontroller.
+//!
+//! ## Example
+//!
+//! ```rust,no_run
+//! use blinksy_esp::time::elapsed;
+//!
+//! loop {
+//!     // Get the current time in milliseconds
+//!     let elapsed_in_ms = elapsed().as_millis();
+//!
+//!     // Use this time to update your animations
+//!     // control.tick(elapsed_in_ms);
+//! }
+//! ```
+
+use esp_hal::time::{Duration, Instant};
+
+/// Returns the elapsed time since system boot.
+pub fn elapsed() -> Duration {
+    Instant::now().duration_since_epoch()
+}

--- a/esp/gledopto/README.md
+++ b/esp/gledopto/README.md
@@ -2,7 +2,7 @@
 
 Rust **no-std** [embedded](https://github.com/rust-embedded/awesome-embedded-rust) board support crate for Gledopto ESP32 Digital LED controllers.
 
-Uses [Blinksy](https://github.com/ahdinosaur/blinksy): an LED control library designed for 1D, 2D, and 3D (audio-reactive) LED setups, inspired by [FastLED](https://fastled.io/) and [WLED](https://kno.wled.ge/).
+Uses [Blinksy](https://github.com/ahdinosaur/blinksy): an LED control library for 1D, 2D, and soon 3D LED setups, inspired by [FastLED](https://fastled.io/) and [WLED](https://kno.wled.ge/).
 
 ## Supported Boards
 
@@ -14,7 +14,7 @@ Select the board by using its respective feature.
 
 ## Features
 
-- [x] 1D, 2D, or 3D LED control using [`blinksy`](https://github.com/ahdinosaur/blinksy)
+- [x] LED control using [`blinksy`](https://github.com/ahdinosaur/blinksy)
 - [x] Built-in "Function" button
 - [ ] Alternative "IO33" button
 - [ ] Built-in microphone
@@ -155,10 +155,23 @@ Run an example:
 cargo run --release -p gledopto --example ws2812-strip
 ```
 
-## Resources
+To start your own project, use [esp-generate](https://docs.esp-rs.org/book/writing-your-own-application/generate-project/esp-generate.html).
 
-- Rust on ESP book: https://docs.esp-rs.org/book
-- ESP no-std book: https://docs.esp-rs.org/no_std-training
-- ESP no-std examples: https://github.com/esp-rs/no_std-training
-- Gledopto GL-C-016WL-D page: https://www.gledopto.eu/gledopto-esp32-wled-uart_1
-- Gledopto GL-C-016WL-D user instructions: https://www.gledopto.eu/mediafiles/anleitungen/7002-gl-c-016wl-d-eng.pdf
+- Enable unstable HAL features: yes
+- Use defmt to print messages: yes
+
+### Resources
+
+As the Gledopto controller is an ESP32, if you want to get started here are some more resources to help:
+
+- [The Rust on ESP Book](https://docs.esp-rs.org/book/introduction.html): An overall guide on ESP32 on Rust
+- [esp-hal](https://docs.espressif.com/projects/rust/esp-hal/1.0.0-beta.0/esp32/esp_hal/index.html): The Hardware Abstraction Layer for an ESP32 on Rust
+- [espup](https://docs.esp-rs.org/book/installation/riscv-and-xtensa.html): How to install the Xtensa target for Rust, required for ESP32
+- [esp-generate](https://docs.esp-rs.org/book/writing-your-own-application/generate-project/esp-generate.html): A template to help you kickstart your project
+
+And in case they are helpful:
+
+- [ESP no-std book](https://docs.esp-rs.org/no_std-training)
+- [ESP no-std examples](https://github.com/esp-rs/no_std-training)
+- [Gledopto GL-C-016WL-D page](https://www.gledopto.eu/gledopto-esp32-wled-uart_1)
+- [Gledopto GL-C-016WL-D user instructions](https://www.gledopto.eu/mediafiles/anleitungen/7002-gl-c-016wl-d-eng.pdf)

--- a/esp/gledopto/src/lib.rs
+++ b/esp/gledopto/src/lib.rs
@@ -1,18 +1,35 @@
 //! # Gledopto Board Support Package
 //!
-//! This module provides a board support package (BSP) for the Gledopto GL-C-016WL-D
-//! LED controller, which is based on the ESP32 microcontroller. It integrates
-//! Blinksy with ESP32-specific functionality for a streamlined development experience.
+//! Rust **no-std** [embedded](https://github.com/rust-embedded/awesome-embedded-rust) board support crate for Gledopto ESP32 Digital LED controllers.
+//!
+//! Uses [Blinksy](https://github.com/ahdinosaur/blinksy): an LED control library for 1D, 2D, and soon 3D LED setups, inspired by [FastLED](https://fastled.io/) and [WLED](https://kno.wled.ge/).
+//!
+//! ## Supported Boards
+//!
+//! Currently this library only supports one board:
+//!
+//! - [x] [Gledopto GL-C-016WL-D](https://www.gledopto.eu/gledopto-esp32-wled-uart_1), `gl_c_016wl_d`
+//!
+//! Select the board by using its respective feature.
 //!
 //! ## Features
 //!
-//! - Integration with ESP32 HAL for hardware access
-//! - Convenient macros for board initialization and peripheral setup
-//! - Support for common LED drivers
-//! - Function button handling
-//! - Time management utilities
+//! - [x] LED control using [`blinksy`](https://github.com/ahdinosaur/blinksy)
+//! - [x] Built-in "Function" button
+//! - [ ] Alternative "IO33" button
+//! - [ ] Built-in microphone
 //!
-//! ## Usage Examples
+//!
+//!
+//! ## Getting started
+//!
+//! For help to get started, see ["Getting Started"][getting-started] section in README.
+//!
+//! [getting-started]: https://github.com/ahdinosaur/blinksy/blob/gledopto/v0.3.1/esp/gledopto/README.md
+//!
+//! ## Examples
+//!
+//! ### 1D WS2812 Strip with Rainbow Pattern
 //!
 //! ```rust,no-run
 //! #![no_std]
@@ -41,6 +58,52 @@
 //!         .build();
 //!
 //!     control.set_brightness(0.2);
+//!
+//!     loop {
+//!         let elapsed_in_ms = elapsed().as_millis();
+//!         control.tick(elapsed_in_ms).unwrap();
+//!     }
+//! }
+//! ```
+//!
+//! ### 2D APA102 Grid with Noise Pattern
+//!
+//! ```rust,no-run
+//! #![no_std]
+//! #![no_main]
+//!
+//! use blinksy::{
+//!     layout::{Shape2d, Vec2},
+//!     layout2d,
+//!     patterns::noise::{noise_fns, Noise2d, NoiseParams},
+//!     ControlBuilder,
+//! };
+//! use gledopto::{apa102, board, elapsed, main};
+//!
+//! #[main]
+//! fn main() -> ! {
+//!     let p = board!();
+//!
+//!     layout2d!(
+//!         Layout,
+//!         [Shape2d::Grid {
+//!             start: Vec2::new(-1., -1.),
+//!             row_end: Vec2::new(1., -1.),
+//!             col_end: Vec2::new(-1., 1.),
+//!             row_pixel_count: 16,
+//!             col_pixel_count: 16,
+//!             serpentine: true,
+//!         }]
+//!     );
+//!     let mut control = ControlBuilder::new_2d()
+//!         .with_layout::<Layout>()
+//!         .with_pattern::<Noise2d<noise_fns::Perlin>>(NoiseParams {
+//!             ..Default::default()
+//!         })
+//!         .with_driver(apa102!(p))
+//!         .build();
+//!
+//!     control.set_brightness(0.1);
 //!
 //!     loop {
 //!         let elapsed_in_ms = elapsed().as_millis();

--- a/esp/gledopto/src/lib.rs
+++ b/esp/gledopto/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! ### 1D WS2812 Strip with Rainbow Pattern
 //!
-//! ```rust,no-run
+//! ```rust,no_run
 //! #![no_std]
 //! #![no_main]
 //!
@@ -68,7 +68,7 @@
 //!
 //! ### 2D APA102 Grid with Noise Pattern
 //!
-//! ```rust,no-run
+//! ```rust,no_run
 //! #![no_std]
 //! #![no_main]
 //!

--- a/esp/gledopto/src/lib.rs
+++ b/esp/gledopto/src/lib.rs
@@ -119,11 +119,10 @@ pub use blinksy;
 
 /// Re-export of the ESP32-specific Blinksy extensions
 pub use blinksy_esp;
+pub use blinksy_esp::time::elapsed;
 
 /// Re-export of the ESP32 HAL
 pub use esp_hal as hal;
-
-use esp_hal::time::{Duration, Instant};
 
 /// Re-export the main macro from esp_hal for entry point definition
 pub use hal::main;
@@ -158,13 +157,6 @@ macro_rules! board {
         let config = $crate::hal::Config::default().with_cpu_clock(cpu_clock);
         $crate::hal::init(config)
     }};
-}
-
-/// Returns the elapsed time since system boot.
-///
-/// This function provides a consistent timing reference for animations and patterns.
-pub fn elapsed() -> Duration {
-    Instant::now().duration_since_epoch()
 }
 
 /// Creates a function button instance connected to GPIO0.

--- a/justfile
+++ b/justfile
@@ -25,7 +25,13 @@ test-core:
   cargo test
 
 check-esp:
-  cd esp && cargo check
+  cd esp && cargo check -F esp32 -F gl_c_016wl_d
+
+test-esp: check-esp
+  cd esp && cargo test --doc -F esp32 -F gl_c_016wl_d
+
+doc-esp:
+  cd esp && cargo doc -F esp32 -F gl_c_016wl_d --open
 
 ##
 # Releasing


### PR DESCRIPTION
Also move `elapsed()` function to `blinksy-esp` crate.

The goal is to make these crates more accessible to a new onlooker.