### PR TITLE
Use bluurryy/noise-functions instead of Razaekel/noise-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
  "fugit",
  "glam",
  "heapless",
- "noise-fork-nostd",
+ "noise-functions",
  "num-traits",
  "smart-leds-trait",
 ]
@@ -511,14 +511,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
-name = "noise-fork-nostd"
-version = "0.9.0"
+name = "noise-functions"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0eb27381fa459e4ea14a5d69240e32b48732de5aaeaf0e4a6f6c95199a8d5a3"
+checksum = "3420c74fd988a5c7da54fad9b8dba218f15431833817913d252dc59002c199c5"
 dependencies = [
- "num-traits",
- "rand",
- "rand_xorshift",
+ "libm",
 ]
 
 [[package]]
@@ -767,30 +765,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]

--- a/blinksy/Cargo.toml
+++ b/blinksy/Cargo.toml
@@ -17,6 +17,6 @@ embedded-hal = "1.0.0"
 fugit = "0.3.7"
 glam = { version = "0.30.1", default-features = false, features = ["libm"] }
 heapless = "0.8.0"
-noise = { package = "noise-fork-nostd", version = "0.9.0", default-features = false, features = ["libm"] }
+noise-functions = { version = "0.8", default-features = false, features = ["libm"] }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 smart-leds-trait = "0.3.1"

--- a/esp/Cargo.lock
+++ b/esp/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
  "fugit",
  "glam",
  "heapless",
- "noise-fork-nostd",
+ "noise-functions",
  "num-traits",
  "smart-leds-trait",
 ]
@@ -500,7 +500,7 @@ dependencies = [
  "nb 1.1.0",
  "paste",
  "portable-atomic",
- "rand_core 0.6.4",
+ "rand_core",
  "riscv",
  "serde",
  "strum 0.27.1",
@@ -855,14 +855,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
-name = "noise-fork-nostd"
-version = "0.9.0"
+name = "noise-functions"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0eb27381fa459e4ea14a5d69240e32b48732de5aaeaf0e4a6f6c95199a8d5a3"
+checksum = "3420c74fd988a5c7da54fad9b8dba218f15431833817913d252dc59002c199c5"
 dependencies = [
- "num-traits",
- "rand",
- "rand_xorshift",
+ "libm",
 ]
 
 [[package]]
@@ -973,35 +971,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46b71a9d9206e8b46714c74255adcaea8b11e0350c1d8456165073c3f75fc81a"
 
 [[package]]
-name = "rand"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
-dependencies = [
- "rand_core 0.9.3",
- "zerocopy",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core 0.9.3",
-]
 
 [[package]]
 name = "rgb"
@@ -1393,26 +1366,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11277b1e4cbb7ffe44678c668518b249c843c81df249b8f096701757bc50d7ee"
 dependencies = [
  "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn",


### PR DESCRIPTION
Closes #48, closes #49

Seems [`noise-rs`](https://github.com/Razaekel/noise-rs) crates a permutation table for every noise function you want to query. Instead, [`noise-functions`](https://github.com/bluurryy/noise-functions) seems more suitable for embedded micros: it uses the same static data for any number of noise functions/seeds, plus it uses f32 instead of f64 which matches what we use. Also it has proper no-std support built-in, so I can drop [my fork of  `noise-rs`](https://github.com/Razaekel/noise-rs/pull/367).