### PR TITLE
Pixels buffer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
 
+
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "ci"
@@ -148,6 +149,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
+          components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 Migration guide (0.10 -> UNRELEASED)
 
-- `ControlBuilder::with_layout` now expects a new const generic `<Layout, const PIXEL_COUNT: usize>`
+- `ControlBuilder::with_layout` generic type signature changes from `<Layout`> to `<Layout, const PIXEL_COUNT: usize>`
+  - If your layout is `Layout`, then change `.with_layout<Layout>()` to `.with_layout::<Layout, { Layout::PIXEL_COUNT }>()`
 
 ```diff
--        .with_layout::<Layout>()
-+        .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
+-  .with_layout::<Layout>()
++  .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
 ```
 
 Breaking changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## UNRELEASED
+
+Migration guide (0.10 -> UNRELEASED)
+
+- `ControlBuilder::with_layout` now expects a new const generic `<Layout, const PIXEL_COUNT: usize>`
+
+```diff
+-        .with_layout::<Layout>()
++        .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
+```
+
+Breaking changes:
+
+- [#82](https://github.com/ahdinosaur/blinksy/pull/82): Use pixels buffer
+  - Write all colors from `Pattern` iterator to pixel buffer, then write pixel buffer to LEDs with `Driver`.
+
+
 ## 0.10
 
 Yee haw `blinksy` now supports async!

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
 dependencies = [
  "hash32",
  "stable_deref_trait",

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ fn main() -> ! {
     );
 
     let mut control = ControlBuilder::new_3d()
-        .with_layout::<Layout>()
+        .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
         .with_pattern::<Noise3d<noise_fns::Perlin>>(NoiseParams {
             ..Default::default()
         })
@@ -296,7 +296,7 @@ https://github.com/user-attachments/assets/22f388d0-189e-44bd-acbf-186a142b956d
 
 ```rust
 use blinksy::{
-    layout::{Shape2d, Vec2},
+    layout::{Layout2d, Shape2d, Vec2},
     layout2d,
     patterns::noise::{noise_fns, Noise2d, NoiseParams},
     ControlBuilder,
@@ -322,7 +322,7 @@ layout2d!(
 fn main() {
     Desktop::new_2d::<PanelLayout>().start(|driver| {
         let mut control = ControlBuilder::new_2d()
-            .with_layout::<PanelLayout>()
+            .with_layout::<PanelLayout, { PanelLayout::PIXEL_COUNT }>()
             .with_pattern::<Noise2d<noise_fns::Perlin>>(NoiseParams {
                 ..Default::default()
             })
@@ -356,6 +356,7 @@ https://github.com/user-attachments/assets/703fe31d-e7ca-4e08-ae2b-7829c0d4d52e
 #![no_main]
 
 use blinksy::{
+    layout::Layout1d,
     layout1d,
     patterns::rainbow::{Rainbow, RainbowParams},
     ControlBuilder,
@@ -369,7 +370,7 @@ fn main() -> ! {
     layout1d!(Layout, 60 * 5);
 
     let mut control = ControlBuilder::new_1d()
-        .with_layout::<Layout>()
+        .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
         .with_pattern::<Rainbow>(RainbowParams::default())
         .with_driver(ws2812!(p, Layout::PIXEL_COUNT))
         .build();
@@ -396,6 +397,7 @@ fn main() -> ! {
 #![feature(impl_trait_in_assoc_type)]
 
 use blinksy::{
+    layout::Layout1d,
     layout1d,
     patterns::rainbow::{Rainbow, RainbowParams},
     ControlBuilder,
@@ -412,7 +414,7 @@ async fn main(_spawner: Spawner) {
     layout1d!(Layout, 60 * 5);
 
     let mut control = ControlBuilder::new_1d_async()
-        .with_layout::<Layout>()
+        .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
         .with_pattern::<Rainbow>(RainbowParams::default())
         .with_driver(ws2812_async!(p, Layout::PIXEL_COUNT))
         .build();
@@ -442,7 +444,7 @@ https://github.com/user-attachments/assets/1c1cf3a2-f65c-4152-b444-29834ac749ee
 #![no_main]
 
 use blinksy::{
-    layout::{Shape2d, Vec2},
+    layout::{Layout2d, Shape2d, Vec2},
     layout2d,
     patterns::noise::{noise_fns, Noise2d, NoiseParams},
     ControlBuilder,
@@ -467,7 +469,7 @@ fn main() -> ! {
         }]
     );
     let mut control = ControlBuilder::new_2d()
-        .with_layout::<Layout>()
+        .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
         .with_pattern::<Noise2d<noise_fns::Perlin>>(NoiseParams::default())
         .with_driver(apa102!(p))
         .build();
@@ -494,7 +496,7 @@ fn main() -> ! {
 #![feature(impl_trait_in_assoc_type)]
 
 use blinksy::{
-    layout::{Shape2d, Vec2},
+    layout::{Layout2d, Shape2d, Vec2},
     layout2d,
     patterns::noise::{noise_fns, Noise2d, NoiseParams},
     ControlBuilder,
@@ -520,7 +522,7 @@ async fn main(_spawner: Spawner) {
         }]
     );
     let mut control = ControlBuilder::new_2d_async()
-        .with_layout::<Layout>()
+        .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
         .with_pattern::<Noise2d<noise_fns::Perlin>>(NoiseParams::default())
         .with_driver(apa102_async!(p))
         .build();

--- a/blinksy-desktop/examples/1d-rainbow.rs
+++ b/blinksy-desktop/examples/1d-rainbow.rs
@@ -1,4 +1,5 @@
 use blinksy::{
+    layout::Layout1d,
     layout1d,
     patterns::rainbow::{Rainbow, RainbowParams},
     ControlBuilder,
@@ -14,7 +15,7 @@ layout1d!(StripLayout, 30);
 fn main() {
     Desktop::new_1d::<StripLayout>().start(|driver| {
         let mut control = ControlBuilder::new_1d()
-            .with_layout::<StripLayout>()
+            .with_layout::<StripLayout, { StripLayout::PIXEL_COUNT }>()
             .with_pattern::<Rainbow>(RainbowParams {
                 ..Default::default()
             })

--- a/blinksy-desktop/examples/2d-noise.rs
+++ b/blinksy-desktop/examples/2d-noise.rs
@@ -1,5 +1,5 @@
 use blinksy::{
-    layout::{Shape2d, Vec2},
+    layout::{Layout2d, Shape2d, Vec2},
     layout2d,
     patterns::noise::{noise_fns, Noise2d, NoiseParams},
     ControlBuilder,
@@ -25,7 +25,7 @@ layout2d!(
 fn main() {
     Desktop::new_2d::<PanelLayout>().start(|driver| {
         let mut control = ControlBuilder::new_2d()
-            .with_layout::<PanelLayout>()
+            .with_layout::<PanelLayout, { PanelLayout::PIXEL_COUNT }>()
             .with_pattern::<Noise2d<noise_fns::Perlin>>(NoiseParams {
                 ..Default::default()
             })

--- a/blinksy-desktop/examples/2d-rainbow.rs
+++ b/blinksy-desktop/examples/2d-rainbow.rs
@@ -1,5 +1,5 @@
 use blinksy::{
-    layout::{Shape2d, Vec2},
+    layout::{Layout2d, Shape2d, Vec2},
     layout2d,
     patterns::rainbow::{Rainbow, RainbowParams},
     ControlBuilder,
@@ -25,7 +25,7 @@ layout2d!(
 fn main() {
     Desktop::new_2d::<PanelLayout>().start(|driver| {
         let mut control = ControlBuilder::new_2d()
-            .with_layout::<PanelLayout>()
+            .with_layout::<PanelLayout, { PanelLayout::PIXEL_COUNT }>()
             .with_pattern::<Rainbow>(RainbowParams {
                 ..Default::default()
             })

--- a/blinksy-desktop/examples/3d-arcs.rs
+++ b/blinksy-desktop/examples/3d-arcs.rs
@@ -1,5 +1,5 @@
 use blinksy::{
-    layout::{Shape3d, Vec3},
+    layout::{Layout3d, Shape3d, Vec3},
     layout3d,
     patterns::noise::{noise_fns, Noise3d, NoiseParams},
     ControlBuilder,
@@ -63,7 +63,7 @@ layout3d!(
 fn main() {
     Desktop::new_3d::<TunnelLayout>().start(|driver| {
         let mut control = ControlBuilder::new_3d()
-            .with_layout::<TunnelLayout>()
+            .with_layout::<TunnelLayout, { TunnelLayout::PIXEL_COUNT }>()
             .with_pattern::<Noise3d<noise_fns::Perlin>>(NoiseParams {
                 ..Default::default()
             })

--- a/blinksy-desktop/examples/3d-cube-face-noise.rs
+++ b/blinksy-desktop/examples/3d-cube-face-noise.rs
@@ -1,5 +1,5 @@
 use blinksy::{
-    layout::{Shape3d, Vec3},
+    layout::{Layout3d, Shape3d, Vec3},
     layout3d,
     patterns::noise::{noise_fns, Noise3d, NoiseParams},
     ControlBuilder,
@@ -73,7 +73,7 @@ fn main() {
 
     Desktop::new_3d::<CubeFaceLayout>().start(|driver| {
         let mut control = ControlBuilder::new_3d()
-            .with_layout::<CubeFaceLayout>()
+            .with_layout::<CubeFaceLayout, { CubeFaceLayout::PIXEL_COUNT }>()
             .with_pattern::<Noise3d<noise_fns::Perlin>>(NoiseParams {
                 ..Default::default()
             })

--- a/blinksy-desktop/examples/3d-cube-volume-noise.rs
+++ b/blinksy-desktop/examples/3d-cube-volume-noise.rs
@@ -41,7 +41,7 @@ impl Layout3d for CubeVolumeLayout {
 fn main() {
     Desktop::new_3d::<CubeVolumeLayout>().start(|driver| {
         let mut control = ControlBuilder::new_3d()
-            .with_layout::<CubeVolumeLayout>()
+            .with_layout::<CubeVolumeLayout, { CubeVolumeLayout::PIXEL_COUNT }>()
             .with_pattern::<Noise3d<noise_fns::Perlin>>(NoiseParams {
                 time_scalar: 0.25 / 1e3,
                 position_scalar: 0.25,

--- a/blinksy-desktop/examples/3d-cube-volume-rainbow.rs
+++ b/blinksy-desktop/examples/3d-cube-volume-rainbow.rs
@@ -41,7 +41,7 @@ impl Layout3d for CubeVolumeLayout {
 fn main() {
     Desktop::new_3d::<CubeVolumeLayout>().start(|driver| {
         let mut control = ControlBuilder::new_3d()
-            .with_layout::<CubeVolumeLayout>()
+            .with_layout::<CubeVolumeLayout, { CubeVolumeLayout::PIXEL_COUNT }>()
             .with_pattern::<Rainbow>(RainbowParams::default())
             .with_driver(driver)
             .build();

--- a/blinksy-desktop/src/driver.rs
+++ b/blinksy-desktop/src/driver.rs
@@ -22,8 +22,8 @@
 //! ```rust,no_run
 //! use blinksy::{
 //!     ControlBuilder,
+//!     layout::{Layout2d, Shape2d, Vec2},
 //!     layout2d,
-//!     layout::{Shape2d, Vec2},
 //!     patterns::rainbow::{Rainbow, RainbowParams}
 //! };
 //! use blinksy_desktop::{driver::Desktop, time::elapsed_in_ms};
@@ -44,7 +44,7 @@
 //! Desktop::new_2d::<PanelLayout>().start(|driver| {
 //!     // Create a control using the Desktop driver instead of physical hardware
 //!     let mut control = ControlBuilder::new_2d()
-//!         .with_layout::<PanelLayout>()
+//!         .with_layout::<PanelLayout, { PanelLayout::PIXEL_COUNT }>()
 //!         .with_pattern::<Rainbow>(RainbowParams::default())
 //!         .with_driver(driver)
 //!         .build();

--- a/blinksy-desktop/src/lib.rs
+++ b/blinksy-desktop/src/lib.rs
@@ -10,7 +10,7 @@
 //! use blinksy::{
 //!     ControlBuilder,
 //!     layout2d,
-//!     layout::{Shape2d, Vec2},
+//!     layout::{Layout2d, Shape2d, Vec2},
 //!     patterns::rainbow::{Rainbow, RainbowParams}
 //! };
 //! use blinksy_desktop::{driver::Desktop, time::elapsed_in_ms};
@@ -32,7 +32,7 @@
 //! Desktop::new_2d::<PanelLayout>().start(|driver| {
 //!     // Create a control using the desktop driver instead of physical hardware
 //!     let mut control = ControlBuilder::new_2d()
-//!         .with_layout::<PanelLayout>()
+//!         .with_layout::<PanelLayout, { PanelLayout::PIXEL_COUNT }>()
 //!         .with_pattern::<Rainbow>(RainbowParams::default())
 //!         .with_driver(driver)
 //!         .build();

--- a/blinksy/Cargo.toml
+++ b/blinksy/Cargo.toml
@@ -17,7 +17,7 @@ embedded-hal = "1.0.0"
 embedded-hal-async = { version = "1.0.0", optional = true }
 fugit = "0.3.7"
 glam = { version = "0.30.1", default-features = false, features = ["libm"] }
-heapless = "0.8.0"
+heapless = "0.9.1"
 noise-functions = { version = "0.8", default-features = false, features = ["libm"] }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 smart-leds-trait = "0.3.1"

--- a/blinksy/src/control.rs
+++ b/blinksy/src/control.rs
@@ -39,7 +39,7 @@ use crate::{driver::DriverAsync as DriverAsyncTrait, markers::Async};
 /// # Type Parameters
 ///
 /// * `PIXEL_COUNT` - The number of LEDs in the layout
-/// * `Dim` - The dimension marker ([`Dim1d`] or [`Dim2d`])
+/// * `Dim` - The dimension marker ([`Dim1d`] or [`Dim2d`] or [`Dim3d`])
 /// * `Layout` - The [`layout`](crate::layout) type
 /// * `Pattern` - The [`pattern`](crate::pattern) type
 /// * `Driver` - The LED [`driver`](crate::driver) type
@@ -49,6 +49,7 @@ use crate::{driver::DriverAsync as DriverAsyncTrait, markers::Async};
 /// ```rust,ignore
 /// use blinksy::{
 ///     ControlBuilder,
+///     layout::Layout1d,
 ///     layout1d,
 ///     patterns::rainbow::{Rainbow, RainbowParams}
 /// };
@@ -58,7 +59,7 @@ use crate::{driver::DriverAsync as DriverAsyncTrait, markers::Async};
 ///
 /// // Create a control system
 /// let mut control = ControlBuilder::new_1d()
-///     .with_layout::<Layout>()
+///     .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
 ///     .with_pattern::<Rainbow>(RainbowParams::default())
 ///     .with_driver(/* LED driver */)
 ///     .build();
@@ -77,6 +78,7 @@ use crate::{driver::DriverAsync as DriverAsyncTrait, markers::Async};
 /// ```rust,ignore
 /// use blinksy::{
 ///     ControlBuilder,
+///     layout::Layout1d,
 ///     layout1d,
 ///     patterns::rainbow::{Rainbow, RainbowParams}
 /// };
@@ -86,7 +88,7 @@ use crate::{driver::DriverAsync as DriverAsyncTrait, markers::Async};
 ///
 /// // Create a control system
 /// let mut control = ControlBuilder::new_1d_async()
-///     .with_layout::<Layout>()
+///     .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
 ///     .with_pattern::<Rainbow>(RainbowParams::default())
 ///     .with_driver(/* LED driver */)
 ///     .build();
@@ -346,6 +348,7 @@ impl<Dim, Exec, Pattern, Driver> ControlBuilder<0, Dim, Exec, (), Pattern, Drive
     /// # Type Parameters
     ///
     /// * `Layout` - The layout type implementing Layout that corresponds to Dim
+    /// * `PIXEL_COUNT` - A constant for the number of pixels (`Layout::PIXEL_COUNT`)
     ///
     /// # Returns
     ///

--- a/blinksy/src/control.rs
+++ b/blinksy/src/control.rs
@@ -225,7 +225,7 @@ where
 ///
 /// The builder allows your to build up your [`Control`] system one-by-one
 /// and handles the combination of generic types and contraints that [`Control`] expects.
-pub struct ControlBuilder<Dim, Exec, Layout, Pattern, Driver> {
+pub struct ControlBuilder<Dim, Exec, Layout, const NUM_PIXELS: usize, Pattern, Driver> {
     dim: PhantomData<Dim>,
     exec: PhantomData<Exec>,
     layout: PhantomData<Layout>,
@@ -233,13 +233,13 @@ pub struct ControlBuilder<Dim, Exec, Layout, Pattern, Driver> {
     driver: Driver,
 }
 
-impl ControlBuilder<(), (), (), (), ()> {
+impl ControlBuilder<(), (), (), 0, (), ()> {
     /// Starts building a one-dimensional blocking control system.
     ///
     /// # Returns
     ///
     /// A builder initialized for 1D, blocking
-    pub fn new_1d() -> ControlBuilder<Dim1d, Blocking, (), (), ()> {
+    pub fn new_1d() -> ControlBuilder<Dim1d, Blocking, (), 0, (), ()> {
         ControlBuilder {
             dim: PhantomData,
             exec: PhantomData,
@@ -268,13 +268,13 @@ impl ControlBuilder<(), (), (), (), ()> {
     }
 }
 
-impl ControlBuilder<(), (), (), (), ()> {
+impl ControlBuilder<(), (), (), 0, (), ()> {
     /// Starts building a two-dimensional blocking control system.
     ///
     /// # Returns
     ///
     /// A builder initialized for 2D, blocking
-    pub fn new_2d() -> ControlBuilder<Dim2d, Blocking, (), (), ()> {
+    pub fn new_2d() -> ControlBuilder<Dim2d, Blocking, (), 0, (), ()> {
         ControlBuilder {
             dim: PhantomData,
             exec: PhantomData,
@@ -303,13 +303,13 @@ impl ControlBuilder<(), (), (), (), ()> {
     }
 }
 
-impl ControlBuilder<(), (), (), (), ()> {
+impl ControlBuilder<(), (), (), 0, (), ()> {
     /// Starts building a three-dimensional blocking control system.
     ///
     /// # Returns
     ///
     /// A builder initialized for 3D, blocking
-    pub fn new_3d() -> ControlBuilder<Dim3d, Blocking, (), (), ()> {
+    pub fn new_3d() -> ControlBuilder<Dim3d, Blocking, (), 0, (), ()> {
         ControlBuilder {
             dim: PhantomData,
             exec: PhantomData,
@@ -338,7 +338,7 @@ impl ControlBuilder<(), (), (), (), ()> {
     }
 }
 
-impl<Dim, Exec, Pattern, Driver> ControlBuilder<Dim, Exec, (), Pattern, Driver> {
+impl<Dim, Exec, Pattern, Driver> ControlBuilder<Dim, Exec, (), 0, Pattern, Driver> {
     /// Specifies the layout type for the control system.
     ///
     /// # Type Parameters
@@ -348,7 +348,9 @@ impl<Dim, Exec, Pattern, Driver> ControlBuilder<Dim, Exec, (), Pattern, Driver> 
     /// # Returns
     ///
     /// Builder with layout type specified
-    pub fn with_layout<Layout>(self) -> ControlBuilder<Dim, Exec, Layout, Pattern, Driver>
+    pub fn with_layout<Layout, const NUM_PIXELS: usize>(
+        self,
+    ) -> ControlBuilder<Dim, Exec, Layout, NUM_PIXELS, Pattern, Driver>
     where
         Layout: LayoutForDim<Dim>,
     {

--- a/blinksy/src/control.rs
+++ b/blinksy/src/control.rs
@@ -38,12 +38,12 @@ use crate::{driver::DriverAsync as DriverAsyncTrait, markers::Async};
 ///
 /// # Type Parameters
 ///
-/// * `NUM_PIXELS` - The number of LEDs in the layout
+/// * `PIXEL_COUNT` - The number of LEDs in the layout
 /// * `Dim` - The dimension marker ([`Dim1d`] or [`Dim2d`])
 /// * `Layout` - The [`layout`](crate::layout) type
 /// * `Pattern` - The [`pattern`](crate::pattern) type
 /// * `Driver` - The LED [`driver`](crate::driver) type
-pub struct Control<const NUM_PIXELS: usize, Dim, Exec, Layout, Pattern, Driver>
+pub struct Control<const PIXEL_COUNT: usize, Dim, Exec, Layout, Pattern, Driver>
 where
     Layout: LayoutForDim<Dim>,
     Pattern: PatternTrait<Dim, Layout>,
@@ -51,15 +51,15 @@ where
     dim: PhantomData<Dim>,
     exec: PhantomData<Exec>,
     layout: PhantomData<Layout>,
-    pixels: Vec<Pattern::Color, NUM_PIXELS>,
+    pixels: Vec<Pattern::Color, PIXEL_COUNT>,
     pattern: Pattern,
     driver: Driver,
     brightness: f32,
     correction: ColorCorrection,
 }
 
-impl<const NUM_PIXELS: usize, Dim, Exec, Layout, Pattern, Driver>
-    Control<NUM_PIXELS, Dim, Exec, Layout, Pattern, Driver>
+impl<const PIXEL_COUNT: usize, Dim, Exec, Layout, Pattern, Driver>
+    Control<PIXEL_COUNT, Dim, Exec, Layout, Pattern, Driver>
 where
     Layout: LayoutForDim<Dim>,
     Pattern: PatternTrait<Dim, Layout>,
@@ -86,8 +86,8 @@ where
     }
 }
 
-impl<const NUM_PIXELS: usize, Dim, Layout, Pattern, Driver>
-    Control<NUM_PIXELS, Dim, Blocking, Layout, Pattern, Driver>
+impl<const PIXEL_COUNT: usize, Dim, Layout, Pattern, Driver>
+    Control<PIXEL_COUNT, Dim, Blocking, Layout, Pattern, Driver>
 where
     Layout: LayoutForDim<Dim>,
     Pattern: PatternTrait<Dim, Layout>,
@@ -98,7 +98,7 @@ where
         self.pixels = self.pattern.tick(time_in_ms).collect();
 
         self.driver.write(
-            self.pixels.drain(0..NUM_PIXELS),
+            self.pixels.drain(0..PIXEL_COUNT),
             self.brightness,
             self.correction,
         )
@@ -106,8 +106,8 @@ where
 }
 
 #[cfg(feature = "async")]
-impl<const NUM_PIXELS: usize, Dim, Layout, Pattern, Driver>
-    Control<NUM_PIXELS, Dim, Async, Layout, Pattern, Driver>
+impl<const PIXEL_COUNT: usize, Dim, Layout, Pattern, Driver>
+    Control<PIXEL_COUNT, Dim, Async, Layout, Pattern, Driver>
 where
     Layout: LayoutForDim<Dim>,
     Pattern: PatternTrait<Dim, Layout>,
@@ -125,7 +125,7 @@ where
 ///
 /// The builder allows you to build up your [`Control`] system one-by-one
 /// and handles the combination of generic types and constraints that [`Control`] expects.
-pub struct ControlBuilder<const NUM_PIXELS: usize, Dim, Exec, Layout, Pattern, Driver> {
+pub struct ControlBuilder<const PIXEL_COUNT: usize, Dim, Exec, Layout, Pattern, Driver> {
     dim: PhantomData<Dim>,
     exec: PhantomData<Exec>,
     layout: PhantomData<Layout>,
@@ -209,9 +209,9 @@ impl ControlBuilder<0, (), (), (), (), ()> {
 }
 
 impl<Dim, Exec, Pattern, Driver> ControlBuilder<0, Dim, Exec, (), Pattern, Driver> {
-    pub fn with_layout<Layout, const NUM_PIXELS: usize>(
+    pub fn with_layout<Layout, const PIXEL_COUNT: usize>(
         self,
-    ) -> ControlBuilder<NUM_PIXELS, Dim, Exec, Layout, Pattern, Driver>
+    ) -> ControlBuilder<PIXEL_COUNT, Dim, Exec, Layout, Pattern, Driver>
     where
         Layout: LayoutForDim<Dim>,
     {
@@ -225,15 +225,15 @@ impl<Dim, Exec, Pattern, Driver> ControlBuilder<0, Dim, Exec, (), Pattern, Drive
     }
 }
 
-impl<const NUM_PIXELS: usize, Dim, Exec, Layout, Driver>
-    ControlBuilder<NUM_PIXELS, Dim, Exec, Layout, (), Driver>
+impl<const PIXEL_COUNT: usize, Dim, Exec, Layout, Driver>
+    ControlBuilder<PIXEL_COUNT, Dim, Exec, Layout, (), Driver>
 where
     Layout: LayoutForDim<Dim>,
 {
     pub fn with_pattern<Pattern>(
         self,
         params: Pattern::Params,
-    ) -> ControlBuilder<NUM_PIXELS, Dim, Exec, Layout, Pattern, Driver>
+    ) -> ControlBuilder<PIXEL_COUNT, Dim, Exec, Layout, Pattern, Driver>
     where
         Pattern: PatternTrait<Dim, Layout>,
     {
@@ -248,13 +248,13 @@ where
     }
 }
 
-impl<const NUM_PIXELS: usize, Dim, Layout, Pattern>
-    ControlBuilder<NUM_PIXELS, Dim, Blocking, Layout, Pattern, ()>
+impl<const PIXEL_COUNT: usize, Dim, Layout, Pattern>
+    ControlBuilder<PIXEL_COUNT, Dim, Blocking, Layout, Pattern, ()>
 {
     pub fn with_driver<Driver>(
         self,
         driver: Driver,
-    ) -> ControlBuilder<NUM_PIXELS, Dim, Blocking, Layout, Pattern, Driver>
+    ) -> ControlBuilder<PIXEL_COUNT, Dim, Blocking, Layout, Pattern, Driver>
     where
         Driver: DriverTrait,
     {
@@ -269,13 +269,13 @@ impl<const NUM_PIXELS: usize, Dim, Layout, Pattern>
 }
 
 #[cfg(feature = "async")]
-impl<const NUM_PIXELS: usize, Dim, Layout, Pattern>
-    ControlBuilder<NUM_PIXELS, Dim, Async, Layout, Pattern, ()>
+impl<const PIXEL_COUNT: usize, Dim, Layout, Pattern>
+    ControlBuilder<PIXEL_COUNT, Dim, Async, Layout, Pattern, ()>
 {
     pub fn with_driver<Driver>(
         self,
         driver: Driver,
-    ) -> ControlBuilder<NUM_PIXELS, Dim, Async, Layout, Pattern, Driver>
+    ) -> ControlBuilder<PIXEL_COUNT, Dim, Async, Layout, Pattern, Driver>
     where
         Driver: DriverAsyncTrait,
     {
@@ -289,29 +289,29 @@ impl<const NUM_PIXELS: usize, Dim, Layout, Pattern>
     }
 }
 
-impl<const NUM_PIXELS: usize, Dim, Layout, Pattern, Driver>
-    ControlBuilder<NUM_PIXELS, Dim, Blocking, Layout, Pattern, Driver>
+impl<const PIXEL_COUNT: usize, Dim, Layout, Pattern, Driver>
+    ControlBuilder<PIXEL_COUNT, Dim, Blocking, Layout, Pattern, Driver>
 where
     Layout: LayoutForDim<Dim>,
     Pattern: PatternTrait<Dim, Layout>,
     Driver: DriverTrait,
     Driver::Color: FromColor<Pattern::Color>,
 {
-    pub fn build(self) -> Control<NUM_PIXELS, Dim, Blocking, Layout, Pattern, Driver> {
+    pub fn build(self) -> Control<PIXEL_COUNT, Dim, Blocking, Layout, Pattern, Driver> {
         Control::new(self.pattern, self.driver)
     }
 }
 
 #[cfg(feature = "async")]
-impl<const NUM_PIXELS: usize, Dim, Layout, Pattern, Driver>
-    ControlBuilder<NUM_PIXELS, Dim, Async, Layout, Pattern, Driver>
+impl<const PIXEL_COUNT: usize, Dim, Layout, Pattern, Driver>
+    ControlBuilder<PIXEL_COUNT, Dim, Async, Layout, Pattern, Driver>
 where
     Layout: LayoutForDim<Dim>,
     Pattern: PatternTrait<Dim, Layout>,
     Driver: DriverAsyncTrait,
     Driver::Color: FromColor<Pattern::Color>,
 {
-    pub fn build(self) -> Control<NUM_PIXELS, Dim, Async, Layout, Pattern, Driver> {
+    pub fn build(self) -> Control<PIXEL_COUNT, Dim, Async, Layout, Pattern, Driver> {
         Control::new(self.pattern, self.driver)
     }
 }

--- a/blinksy/src/control.rs
+++ b/blinksy/src/control.rs
@@ -186,8 +186,9 @@ where
     ///
     /// Result indicating success or an error from the driver
     pub fn tick(&mut self, time_in_ms: u64) -> Result<(), Driver::Error> {
-        self.pixels = self.pattern.tick(time_in_ms).collect();
-
+        // Write colors from Pattern to pixel buffer.
+        self.pixels.extend(self.pattern.tick(time_in_ms));
+        // Write colors in pixel buffer to Driver.
         self.driver.write(
             self.pixels.drain(0..PIXEL_COUNT),
             self.brightness,

--- a/blinksy/src/lib.rs
+++ b/blinksy/src/lib.rs
@@ -120,13 +120,13 @@
 //! ### 1D Strip with Rainbow Pattern (Blocking)
 //!
 //! ```rust,ignore
-//! use blinksy::{ControlBuilder, layout1d, patterns::rainbow::{Rainbow, RainbowParams}};
-//!
+//! # use blinksy::{ControlBuilder, layout::Layout1d, layout1d, patterns::rainbow::{Rainbow, RainbowParams}};
+//! #
 //! // Define a 1D layout with 60 LEDs
 //! layout1d!(Layout, 60);
 //!
 //! let mut control = ControlBuilder::new_1d()
-//!     .with_layout::<Layout>()
+//!     .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
 //!     .with_pattern::<Rainbow>(RainbowParams::default())
 //!     .with_driver(/* insert your LED driver here */)
 //!     .build();
@@ -141,13 +141,13 @@
 //! ### 1D Strip with Rainbow Pattern (Async)
 //!
 //! ```rust,ignore
-//! use blinksy::{ControlBuilder, layout1d, patterns::rainbow::{Rainbow, RainbowParams}};
-//!
+//! # use blinksy::{ControlBuilder, layout::Layout1d, layout1d, patterns::rainbow::{Rainbow, RainbowParams}};
+//! #
 //! // Define a 1D layout with 60 LEDs
 //! layout1d!(Layout, 60);
 //!
 //! let mut control = ControlBuilder::new_1d_async()
-//!     .with_layout::<Layout>()
+//!     .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
 //!     .with_pattern::<Rainbow>(RainbowParams::default())
 //!     .with_driver(/* insert your LED driver here */)
 //!     .build();
@@ -162,13 +162,13 @@
 //! ### 2D Grid with Noise Pattern (Blocking)
 //!
 //! ```rust,ignore
-//! use blinksy::{
-//!     ControlBuilder,
-//!     layout::{Shape2d, Vec2},
-//!     layout2d,
-//!     patterns::noise::{noise_fns, Noise2d, NoiseParams},
-//! };
-//!
+//! # use blinksy::{
+//! #     ControlBuilder,
+//! #     layout::{Layout2d, Shape2d, Vec2},
+//! #     layout2d,
+//! #     patterns::noise::{noise_fns, Noise2d, NoiseParams},
+//! # };
+//! #
 //! layout2d!(
 //!     Layout,
 //!     [Shape2d::Grid {
@@ -181,7 +181,7 @@
 //!     }]
 //! );
 //! let mut control = ControlBuilder::new_2d()
-//!     .with_layout::<Layout>()
+//!     .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
 //!     .with_pattern::<Noise2d<noise_fns::Perlin>>(NoiseParams::default())
 //!     .with_driver(/* insert your LED driver here */)
 //!     .build();
@@ -196,16 +196,13 @@
 //! ### 3D Cube with Noise Pattern (Blocking)
 //!
 //! ```rust,ignore
-//! #![no_std]
-//! #![no_main]
-//!
-//! use blinksy::{
-//!     layout::{Layout3d, Shape3d, Vec3},
-//!     layout3d,
-//!     patterns::noise::{noise_fns, Noise3d, NoiseParams},
-//!     ControlBuilder,
-//! };
-//!
+//! # use blinksy::{
+//! #     layout::{Layout3d, Shape3d, Vec3},
+//! #     layout3d,
+//! #     patterns::noise::{noise_fns, Noise3d, NoiseParams},
+//! #     ControlBuilder,
+//! # };
+//! #
 //! layout3d!(
 //!     Layout,
 //!     [
@@ -267,7 +264,7 @@
 //! );
 //!
 //! let mut control = ControlBuilder::new_3d()
-//!     .with_layout::<Layout>()
+//!     .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
 //!     .with_pattern::<Noise3d<noise_fns::Perlin>>(NoiseParams::default())
 //!     .with_driver(/* insert your LED driver here */)
 //!     .build();

--- a/blinksy/src/patterns/noise.rs
+++ b/blinksy/src/patterns/noise.rs
@@ -25,7 +25,7 @@
 //! use blinksy::{
 //!     ControlBuilder,
 //!     layout2d,
-//!     layout::{Shape2d, Vec2},
+//!     layout::{Layout2d, Shape2d, Vec2},
 //!     patterns::noise::{Noise2d, noise_fns, NoiseParams}
 //! };
 //!
@@ -44,7 +44,7 @@
 //!
 //! // Create a 2D noise pattern with Perlin noise
 //! let control = ControlBuilder::new_2d()
-//!     .with_layout::<Layout>()
+//!     .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
 //!     .with_pattern::<Noise2d<noise_fns::Perlin>>(NoiseParams {
 //!         time_scalar: 0.001,
 //!         position_scalar: 0.1,

--- a/blinksy/src/patterns/rainbow.rs
+++ b/blinksy/src/patterns/rainbow.rs
@@ -9,6 +9,7 @@
 //! ```rust,ignore
 //! use blinksy::{
 //!     ControlBuilder,
+//!     layout::Layout1d,
 //!     layout1d,
 //!     patterns::rainbow::{Rainbow, RainbowParams}
 //! };
@@ -18,7 +19,7 @@
 //!
 //! // Create a Rainbow pattern with custom parameters
 //! let control = ControlBuilder::new_1d()
-//!     .with_layout::<Layout>()
+//!     .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
 //!     .with_pattern::<Rainbow>(RainbowParams {
 //!         time_scalar: 0.1,
 //!         position_scalar: 1.0,

--- a/esp/Cargo.lock
+++ b/esp/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
  "embedded-hal-async",
  "fugit",
  "glam",
- "heapless",
+ "heapless 0.9.1",
  "noise-functions",
  "num-traits",
  "smart-leds-trait",
@@ -350,7 +350,7 @@ dependencies = [
  "embedded-io-async",
  "futures-sink",
  "futures-util",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -364,7 +364,7 @@ dependencies = [
  "embedded-io-async",
  "futures-core",
  "futures-sink",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -399,7 +399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc55c748d16908a65b166d09ce976575fb8852cf60ccd06174092b41064d8f83"
 dependencies = [
  "embassy-executor",
- "heapless",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -1003,6 +1003,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "heapless"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,7 +1511,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
 dependencies = [
- "heapless",
+ "heapless 0.8.0",
  "portable-atomic",
 ]
 

--- a/esp/Cargo.lock
+++ b/esp/Cargo.lock
@@ -57,7 +57,7 @@ checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "blinksy"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "defmt 0.3.100",
  "embedded-hal 1.0.0",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "blinksy-esp"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "blinksy",
  "defmt 0.3.100",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "gledopto"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "blinksy",
  "blinksy-esp",

--- a/esp/blinksy-esp/src/lib.rs
+++ b/esp/blinksy-esp/src/lib.rs
@@ -61,7 +61,7 @@
 //!
 //!     // Build the Blinky controller
 //!     let mut control = ControlBuilder::new_1d()
-//!         .with_layout::<Layout>()
+//!         .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
 //!         .with_pattern::<Rainbow>(RainbowParams {
 //!             ..Default::default()
 //!         })

--- a/esp/gledopto/README.md
+++ b/esp/gledopto/README.md
@@ -34,7 +34,7 @@ https://github.com/user-attachments/assets/1c1cf3a2-f65c-4152-b444-29834ac749ee
 #![no_main]
 
 use blinksy::{
-    layout::{Shape2d, Vec2},
+    layout::{Layout2d, Shape2d, Vec2},
     layout2d,
     patterns::noise::{noise_fns, Noise2d, NoiseParams},
     ControlBuilder,
@@ -59,7 +59,7 @@ fn main() -> ! {
         }]
     );
     let mut control = ControlBuilder::new_2d()
-        .with_layout::<Layout>()
+        .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
         .with_pattern::<Noise2d<noise_fns::Perlin>>(NoiseParams {
             ..Default::default()
         })
@@ -107,7 +107,7 @@ fn main() -> ! {
     layout1d!(Layout, 60 * 5);
 
     let mut control = ControlBuilder::new_1d()
-        .with_layout::<Layout>()
+        .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
         .with_pattern::<Rainbow>(RainbowParams {
             ..Default::default()
         })

--- a/esp/gledopto/examples/apa102-grid-embassy.rs
+++ b/esp/gledopto/examples/apa102-grid-embassy.rs
@@ -3,7 +3,7 @@
 #![feature(impl_trait_in_assoc_type)]
 
 use blinksy::{
-    layout::{Shape2d, Vec2},
+    layout::{Layout2d, Shape2d, Vec2},
     layout2d,
     patterns::noise::{noise_fns, Noise2d, NoiseParams},
     ControlBuilder,
@@ -29,7 +29,7 @@ async fn main(_spawner: Spawner) {
         }]
     );
     let mut control = ControlBuilder::new_2d_async()
-        .with_layout::<Layout>()
+        .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
         .with_pattern::<Noise2d<noise_fns::Perlin>>(NoiseParams::default())
         .with_driver(apa102_async!(p))
         .build();

--- a/esp/gledopto/examples/apa102-grid.rs
+++ b/esp/gledopto/examples/apa102-grid.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use blinksy::{
-    layout::{Shape2d, Vec2},
+    layout::{Layout2d, Shape2d, Vec2},
     layout2d,
     patterns::noise::{noise_fns, Noise2d, NoiseParams},
     ControlBuilder,
@@ -27,7 +27,7 @@ fn main() -> ! {
         }]
     );
     let mut control = ControlBuilder::new_2d()
-        .with_layout::<Layout>()
+        .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
         .with_pattern::<Noise2d<noise_fns::Perlin>>(NoiseParams::default())
         .with_driver(apa102!(p))
         .build();

--- a/esp/gledopto/examples/ws2812-face-cube-embassy.rs
+++ b/esp/gledopto/examples/ws2812-face-cube-embassy.rs
@@ -1,0 +1,96 @@
+#![no_std]
+#![no_main]
+#![feature(impl_trait_in_assoc_type)]
+
+use blinksy::{
+    layout::{Layout3d, Shape3d, Vec3},
+    layout3d,
+    patterns::noise::{noise_fns, Noise3d, NoiseParams},
+    ControlBuilder,
+};
+use embassy_executor::Spawner;
+use gledopto::{board, bootloader, elapsed, init_embassy, main_embassy, ws2812_async};
+
+bootloader!();
+
+#[main_embassy]
+async fn main(_spawner: Spawner) {
+    let p = board!();
+
+    init_embassy!(p);
+
+    layout3d!(
+        Layout,
+        [
+            // bottom face
+            Shape3d::Grid {
+                start: Vec3::new(1., -1., 1.),           // right bottom front
+                horizontal_end: Vec3::new(-1., -1., 1.), // left bottom front
+                vertical_end: Vec3::new(1., -1., -1.),   // right bottom back
+                horizontal_pixel_count: 16,
+                vertical_pixel_count: 16,
+                serpentine: true,
+            },
+            // back face
+            Shape3d::Grid {
+                start: Vec3::new(-1., -1., -1.),         // left bottom back
+                horizontal_end: Vec3::new(-1., 1., -1.), // left top back
+                vertical_end: Vec3::new(1., -1., -1.),   // right bottom back
+                horizontal_pixel_count: 16,
+                vertical_pixel_count: 16,
+                serpentine: true,
+            },
+            // right face
+            Shape3d::Grid {
+                start: Vec3::new(1., 1., -1.),         // right top back
+                horizontal_end: Vec3::new(1., 1., 1.), // right top front
+                vertical_end: Vec3::new(1., -1., -1.), // right bottom back
+                horizontal_pixel_count: 16,
+                vertical_pixel_count: 16,
+                serpentine: true,
+            },
+            // front face
+            Shape3d::Grid {
+                start: Vec3::new(-1., -1., 1.),         // left bottom front
+                horizontal_end: Vec3::new(1., -1., 1.), // right bottom front
+                vertical_end: Vec3::new(-1., 1., 1.),   // left top front
+                horizontal_pixel_count: 16,
+                vertical_pixel_count: 16,
+                serpentine: true,
+            },
+            // left face
+            Shape3d::Grid {
+                start: Vec3::new(-1., 1., -1.),           // left top back
+                horizontal_end: Vec3::new(-1., -1., -1.), // left bottom back
+                vertical_end: Vec3::new(-1., 1., 1.),     // left top front
+                horizontal_pixel_count: 16,
+                vertical_pixel_count: 16,
+                serpentine: true,
+            },
+            // top face
+            Shape3d::Grid {
+                start: Vec3::new(1., 1., 1.),           // right top front
+                horizontal_end: Vec3::new(1., 1., -1.), // right top back
+                vertical_end: Vec3::new(-1., 1., 1.),   // left top front
+                horizontal_pixel_count: 16,
+                vertical_pixel_count: 16,
+                serpentine: true,
+            }
+        ]
+    );
+
+    let mut control = ControlBuilder::new_3d_async()
+        .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
+        .with_pattern::<Noise3d<noise_fns::Perlin>>(NoiseParams {
+            ..Default::default()
+        })
+        .with_driver(ws2812_async!(p, Layout::PIXEL_COUNT))
+        .build();
+
+    control.set_brightness(0.2);
+
+    loop {
+        let elapsed_in_ms = elapsed().as_millis();
+        control.tick(elapsed_in_ms).await.unwrap();
+    }
+}

--- a/esp/gledopto/examples/ws2812-face-cube.rs
+++ b/esp/gledopto/examples/ws2812-face-cube.rs
@@ -76,7 +76,7 @@ fn main() -> ! {
     );
 
     let mut control = ControlBuilder::new_3d()
-        .with_layout::<Layout>()
+        .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
         .with_pattern::<Noise3d<noise_fns::Perlin>>(NoiseParams {
             ..Default::default()
         })

--- a/esp/gledopto/examples/ws2812-strip-embassy.rs
+++ b/esp/gledopto/examples/ws2812-strip-embassy.rs
@@ -3,6 +3,7 @@
 #![feature(impl_trait_in_assoc_type)]
 
 use blinksy::{
+    layout::Layout1d,
     layout1d,
     patterns::rainbow::{Rainbow, RainbowParams},
     ControlBuilder,
@@ -21,7 +22,7 @@ async fn main(_spawner: Spawner) {
     layout1d!(Layout, 60 * 5);
 
     let mut control = ControlBuilder::new_1d_async()
-        .with_layout::<Layout>()
+        .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
         .with_pattern::<Rainbow>(RainbowParams::default())
         .with_driver(ws2812_async!(p, Layout::PIXEL_COUNT))
         .build();

--- a/esp/gledopto/examples/ws2812-strip.rs
+++ b/esp/gledopto/examples/ws2812-strip.rs
@@ -2,6 +2,7 @@
 #![no_main]
 
 use blinksy::{
+    layout::Layout1d,
     layout1d,
     patterns::rainbow::{Rainbow, RainbowParams},
     ControlBuilder,
@@ -17,7 +18,7 @@ fn main() -> ! {
     layout1d!(Layout, 60);
 
     let mut control = ControlBuilder::new_1d()
-        .with_layout::<Layout>()
+        .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
         .with_pattern::<Rainbow>(RainbowParams::default())
         .with_driver(ws2812!(p, Layout::PIXEL_COUNT))
         .build();

--- a/esp/gledopto/examples/ws2812-volume-cube.rs
+++ b/esp/gledopto/examples/ws2812-volume-cube.rs
@@ -46,7 +46,7 @@ fn main() -> ! {
     let p = board!();
 
     let mut control = ControlBuilder::new_3d()
-        .with_layout::<VolumeCubeLayout>()
+        .with_layout::<VolumeCubeLayout, { VolumeCubeLayout::PIXEL_COUNT }>()
         .with_pattern::<Noise3d<noise_fns::Perlin>>(NoiseParams {
             time_scalar: 0.25 / 1e3,
             position_scalar: 0.25,

--- a/esp/gledopto/src/lib.rs
+++ b/esp/gledopto/src/lib.rs
@@ -49,7 +49,7 @@
 //!     layout1d!(Layout, 60 * 5);
 //!
 //!     let mut control = ControlBuilder::new_1d()
-//!         .with_layout::<Layout>()
+//!         .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
 //!         .with_pattern::<Rainbow>(RainbowParams {
 //!             ..Default::default()
 //!         })
@@ -97,7 +97,7 @@
 //!         }]
 //!     );
 //!     let mut control = ControlBuilder::new_2d()
-//!         .with_layout::<Layout>()
+//!         .with_layout::<Layout, { Layout::PIXEL_COUNT }>()
 //!         .with_pattern::<Noise2d<noise_fns::Perlin>>(NoiseParams {
 //!             ..Default::default()
 //!         })

--- a/justfile
+++ b/justfile
@@ -38,6 +38,9 @@ gledopto-apa102-grid-embassy:
 gledopto-ws2812-face-cube:
   cd esp && cargo run --release -p gledopto --example ws2812-face-cube --features gl_c_016wl_d
 
+gledopto-ws2812-face-cube-embassy:
+  cd esp && cargo run --release -p gledopto --example ws2812-face-cube-embassy --features gl_c_016wl_d,embassy
+
 gledopto-ws2812-volume-cube:
   cd esp && cargo run --release -p gledopto --example ws2812-volume-cube --features gl_c_016wl_d
 


### PR DESCRIPTION
This fixes #81, so now the blocking ESP32 RMT driver works.  But in the process discovered #83.

Until Rust supports const generic expressions, where we could pull the associated constant `PIXELS_COUNT` from the `Layout` generic type we already have, we have to change the API so the user provides the `PIXELS_COUNT` directly. To be honest, I'm not sure what feature this is currently being worked on as, something from https://github.com/rust-lang/rust/issues/76560, maybe https://github.com/rust-lang/rust/issues/76560.

Changes:

- Add `const PIXEL_COUNT: usize` const generic to `Control` (and `ControlBuilder`)
  - BREAKING: Change `ControlBuilder::with_layout` signature to have a new const generic: `<Layout, const PIXEL_COUNT: usize>`.
- Write all colors from Pattern iterator to pixel buffer, then write pixel buffer to LEDs with Driver.
- Add async example for cube face layout.