### PR TITLE
add noise-functions behind a feature flag

### DIFF
--- a/blinksy/Cargo.toml
+++ b/blinksy/Cargo.toml
@@ -18,14 +18,15 @@ embedded-hal-async = { version = "1.0.0", optional = true }
 fugit = "0.3.7"
 glam = { version = "0.30.1", default-features = false, features = ["libm"] }
 heapless = "0.9.1"
-noise-functions = { version = "0.8", default-features = false, features = ["libm"] }
+noise-functions = { version = "0.8", default-features = false, features = ["libm"], optional = true }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 smart-leds-trait = "0.3.1"
 
 [features]
-default = []
+default = ["noise"]
 async = ["dep:embedded-hal-async"]
 defmt = ["dep:defmt"]
+noise = ["dep:noise-functions"]
 
 [package.metadata.docs.rs]
 features = ["async"]

--- a/blinksy/src/patterns/mod.rs
+++ b/blinksy/src/patterns/mod.rs
@@ -7,5 +7,6 @@
 //!
 //! If you want help to port a pattern from FastLED / WLED to Rust, [make an issue](https://github.com/ahdinosaur/blinksy/issues)!
 
+#[cfg(feature = "noise")]
 pub mod noise;
 pub mod rainbow;


### PR DESCRIPTION
I'm trying to use blinksy with a arduino pro mini 3.3V and a LPD8806. First issue is that I can't compile noise-functions with avr as target, some error related to avr memory size. I'll probably try to take a look in the next few weeks but this PR will add a (default) feature to enable noise-functions. I'll open another PR with a working LPD8806 driver in the next few days.