### PR TITLE
Pattern control

### DIFF
--- a/blinksy/src/control.rs
+++ b/blinksy/src/control.rs
@@ -102,10 +102,7 @@ pub struct Control<
     Layout,
     Pattern,
     Driver,
-> where
-    Layout: LayoutForDim<Dim>,
-    Pattern: PatternTrait<Dim, Layout>,
-{
+> {
     dim: PhantomData<Dim>,
     exec: PhantomData<Exec>,
     layout: PhantomData<Layout>,
@@ -124,9 +121,6 @@ impl<
         Pattern,
         Driver,
     > Control<PIXEL_COUNT, FRAME_BUFFER_SIZE, Dim, Exec, Layout, Pattern, Driver>
-where
-    Layout: LayoutForDim<Dim>,
-    Pattern: PatternTrait<Dim, Layout>,
 {
     /// Creates a new control system.
     ///
@@ -166,6 +160,54 @@ where
     /// - `correction` - Color correction factors
     pub fn set_color_correction(&mut self, correction: ColorCorrection) {
         self.correction = correction;
+    }
+}
+
+impl<
+        const PIXEL_COUNT: usize,
+        const FRAME_BUFFER_SIZE: usize,
+        Dim,
+        Exec,
+        Layout,
+        Pattern,
+        Driver,
+    > Control<PIXEL_COUNT, FRAME_BUFFER_SIZE, Dim, Exec, Layout, Pattern, Driver>
+where
+    Layout: LayoutForDim<Dim>,
+    Pattern: PatternTrait<Dim, Layout>,
+{
+    /// Sets the params for the pattern.
+    ///
+    /// # Arguments
+    ///
+    /// - `params` - `Pattern::Params`, `Params` type associated with `NextPattern` type.
+    pub fn set_params(&mut self, params: Pattern::Params) {
+        self.pattern.set(params);
+    }
+
+    /// Sets a new pattern (with params) for the control.
+    ///
+    /// # Type parameters
+    ///
+    /// - `NextPattern` - The pattern type implementing Pattern<Dim, Layout>
+    ///
+    /// # Arguments
+    ///
+    /// - `params` - `NextPattern::Params`, `Params` type associated with `NextPattern` type.
+    pub fn set_pattern<NextPattern: PatternTrait<Dim, Layout>>(
+        self,
+        params: NextPattern::Params,
+    ) -> Control<PIXEL_COUNT, FRAME_BUFFER_SIZE, Dim, Exec, Layout, NextPattern, Driver> {
+        let pattern = NextPattern::new(params);
+        Control {
+            dim: PhantomData,
+            exec: PhantomData,
+            layout: PhantomData,
+            pattern,
+            driver: self.driver,
+            brightness: self.brightness,
+            correction: self.correction,
+        }
     }
 }
 

--- a/blinksy/src/pattern.rs
+++ b/blinksy/src/pattern.rs
@@ -60,6 +60,10 @@ use crate::layout::LayoutForDim;
 ///         Self { params }
 ///     }
 ///
+///     fn new(&mut self, params: Self::Params) {
+///         self.params = params;
+///     }
+///
 ///     fn tick(&self, time_in_ms: u64) -> impl Iterator<Item = Self::Color> {
 ///         let offset = (time_in_ms as f32 * self.params.speed);
 ///         let step = 0.5 * self.params.scale;
@@ -83,6 +87,9 @@ where
 
     /// Creates a new pattern instance with the specified parameters.
     fn new(params: Self::Params) -> Self;
+
+    /// Sets an existing pattern instance with the specified parameters.
+    fn set(&mut self, params: Self::Params);
 
     /// Generates colors for all LEDs in the layout at the given time.
     ///

--- a/blinksy/src/patterns/noise.rs
+++ b/blinksy/src/patterns/noise.rs
@@ -123,6 +123,11 @@ where
         }
     }
 
+    /// Sets an existing Noise1d pattern with the specified parameters.
+    fn set(&mut self, params: Self::Params) {
+        self.params = params;
+    }
+
     /// Generates colors for a 1D layout using noise.
     ///
     /// The pattern uses the LED position and time as inputs to a 2D noise function,
@@ -181,6 +186,11 @@ where
             value_noise: Noise::default().seed(1),
             params,
         }
+    }
+
+    /// Sets an existing Noise2d pattern with the specified parameters.
+    fn set(&mut self, params: Self::Params) {
+        self.params = params;
     }
 
     /// Generates colors for a 2D layout using noise.
@@ -248,6 +258,11 @@ where
             value_noise: Noise::default().seed(1),
             params,
         }
+    }
+
+    /// Sets an existing Noise3d pattern with the specified parameters.
+    fn set(&mut self, params: Self::Params) {
+        self.params = params;
     }
 
     /// Generates colors for a 3D layout using noise.

--- a/blinksy/src/patterns/rainbow.rs
+++ b/blinksy/src/patterns/rainbow.rs
@@ -78,6 +78,11 @@ where
         Self { params }
     }
 
+    /// Sets an existing Rainbow pattern with the specified parameters.
+    fn set(&mut self, params: Self::Params) {
+        self.params = params;
+    }
+
     /// Generates colors for a 1D layout.
     ///
     /// The rainbow pattern creates a smooth transition of hues across the layout,
@@ -113,6 +118,11 @@ where
         Self { params }
     }
 
+    /// Sets an existing Rainbow pattern with the specified parameters.
+    fn set(&mut self, params: Self::Params) {
+        self.params = params;
+    }
+
     /// Generates colors for a 2D layout.
     ///
     /// In 2D, the rainbow pattern uses the x-coordinate to determine hue,
@@ -146,6 +156,11 @@ where
     /// Creates a new Rainbow pattern with the specified parameters.
     fn new(params: Self::Params) -> Self {
         Self { params }
+    }
+
+    /// Sets an existing Rainbow pattern with the specified parameters.
+    fn set(&mut self, params: Self::Params) {
+        self.params = params;
     }
 
     /// Generates colors for a 3D layout.


### PR DESCRIPTION
Requested by @luogni,

- Add function `Pattern::set(&mut self, params: Self::Params)`
- Add function `Control::set_params(params: Pattern::Params)`
- Add function `Control::set_pattern<Pattern: PatternTrait>(params: Pattern::Params)`

This fixes #40, but I don't think `control.set_pattern` will actually work for fixing #39, because you can't just change a type on a variable.

So probably best to remove `set_pattern` from this pull request, and try again for a multi-pattern pull request.