### PR TITLE
Add support for Lpd8806

### DIFF
--- a/blinksy/src/leds/lpd8806.rs
+++ b/blinksy/src/leds/lpd8806.rs
@@ -6,19 +6,41 @@ use crate::{
     util::component::Component,
 };
 
+pub trait Lpd8806Order {
+    fn reorder(bytes: [u8; 3]) -> [u8; 3];
+}
+
+pub struct OrderGrb;
+pub struct OrderBrg;
+
+impl Lpd8806Order for OrderGrb {
+    #[inline]
+    fn reorder(bytes: [u8; 3]) -> [u8; 3] {
+        RgbChannels::GRB.reorder(bytes)
+    }
+}
+
+impl Lpd8806Order for OrderBrg {
+    #[inline]
+    fn reorder(bytes: [u8; 3]) -> [u8; 3] {
+        RgbChannels::BRG.reorder(bytes)
+    }
+}
+
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Lpd8806;
+pub struct Lpd8806Generic<O: Lpd8806Order>(core::marker::PhantomData<O>);
 
-impl Lpd8806 {
+pub type Lpd8806 = Lpd8806Generic<OrderGrb>;
+pub type Lpd8806Brg = Lpd8806Generic<OrderBrg>;
+
+impl<O: Lpd8806Order> Lpd8806Generic<O> {
     pub const fn frame_buffer_size(pixel_count: usize) -> usize {
-        // LPD8806 uses a start frame of 32 zeros and an end frame of at least (n/2) zeros (same as APA102)
-        // Each LED uses 3 bytes (G, R, B), each 7-bit data with MSB set
         4 + pixel_count * 3 + (pixel_count - 1).div_ceil(16)
     }
 }
 
-impl ClockedLed for Lpd8806 {
+impl<O: Lpd8806Order> ClockedLed for Lpd8806Generic<O> {
     type Word = u8;
     type Color = LinearSrgb;
 
@@ -31,8 +53,6 @@ impl ClockedLed for Lpd8806 {
         _brightness: f32,
         correction: ColorCorrection,
     ) -> impl IntoIterator<Item = Self::Word> {
-        // LPD8806 uses 7 bits per color and requires the high bit set to 1
-        // Channel order is typically GRB
         let (r, g, b) = (linear_rgb.red, linear_rgb.green, linear_rgb.blue);
 
         let r = r * correction.red;
@@ -45,22 +65,13 @@ impl ClockedLed for Lpd8806 {
             Component::from_normalized_f32(b),
         );
 
-        // Map 16-bit to 7-bit values with rounding, then set MSB
         let to_7bit = |x: u16| -> u8 {
-            // map16_to_8 rounding then clamp to 7 bits
-            let mut v = if x == 0 {
-                0
-            } else if x >= 0xff00 {
-                0xff
-            } else {
-                ((x + 128) >> 8) as u8
-            };
-            v >>= 1; // 7-bit
+            let mut v = if x == 0 { 0 } else if x >= 0xff00 { 0xff } else { ((x + 128) >> 8) as u8 };
+            v >>= 1;
             0x80 | v
         };
 
-        // LPD8806 expects GRB order on the wire
-        let bytes = RgbChannels::GRB.reorder([
+        let bytes = O::reorder([
             to_7bit(r16),
             to_7bit(g16),
             to_7bit(b16),

--- a/blinksy/src/leds/lpd8806.rs
+++ b/blinksy/src/leds/lpd8806.rs
@@ -1,0 +1,76 @@
+use core::iter::repeat_n;
+
+use crate::{
+    color::{ColorCorrection, LinearSrgb, RgbChannels},
+    driver::clocked::ClockedLed,
+    util::component::Component,
+};
+
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Lpd8806;
+
+impl Lpd8806 {
+    pub const fn frame_buffer_size(pixel_count: usize) -> usize {
+        // LPD8806 uses a start frame of 32 zeros and an end frame of at least (n/2) zeros (same as APA102)
+        // Each LED uses 3 bytes (G, R, B), each 7-bit data with MSB set
+        4 + pixel_count * 3 + (pixel_count - 1).div_ceil(16)
+    }
+}
+
+impl ClockedLed for Lpd8806 {
+    type Word = u8;
+    type Color = LinearSrgb;
+
+    fn start() -> impl IntoIterator<Item = Self::Word> {
+        [0x00, 0x00, 0x00, 0x00]
+    }
+
+    fn led(
+        linear_rgb: LinearSrgb,
+        _brightness: f32,
+        correction: ColorCorrection,
+    ) -> impl IntoIterator<Item = Self::Word> {
+        // LPD8806 uses 7 bits per color and requires the high bit set to 1
+        // Channel order is typically GRB
+        let (r, g, b) = (linear_rgb.red, linear_rgb.green, linear_rgb.blue);
+
+        let r = r * correction.red;
+        let g = g * correction.green;
+        let b = b * correction.blue;
+
+        let (r16, g16, b16) = (
+            Component::from_normalized_f32(r),
+            Component::from_normalized_f32(g),
+            Component::from_normalized_f32(b),
+        );
+
+        // Map 16-bit to 7-bit values with rounding, then set MSB
+        let to_7bit = |x: u16| -> u8 {
+            // map16_to_8 rounding then clamp to 7 bits
+            let mut v = if x == 0 {
+                0
+            } else if x >= 0xff00 {
+                0xff
+            } else {
+                ((x + 128) >> 8) as u8
+            };
+            v >>= 1; // 7-bit
+            0x80 | v
+        };
+
+        // LPD8806 expects GRB order on the wire
+        let bytes = RgbChannels::GRB.reorder([
+            to_7bit(r16),
+            to_7bit(g16),
+            to_7bit(b16),
+        ]);
+
+        [bytes[0], bytes[1], bytes[2]]
+    }
+
+    fn end(pixel_count: usize) -> impl IntoIterator<Item = Self::Word> {
+        let num_bytes = (pixel_count - 1).div_ceil(16);
+        repeat_n(0u8, num_bytes)
+    }
+}

--- a/blinksy/src/leds/mod.rs
+++ b/blinksy/src/leds/mod.rs
@@ -3,16 +3,19 @@
 //! - [`Apa102`]: APA102 (DotStar) LEDs
 //! - [`Ws2812`]: WS2812 (NeoPixel) LEDs
 //! - [`Sk6812`]: SK6812 LEDs
+//! - [`Lpd8806`]: LPD8806 LEDs
 //!
 //! If you want help to support a new chipset, [make an issue](https://github.com/ahdinosaur/blinksy/issues)!
 
 mod apa102;
 mod sk6812;
 mod ws2812;
+mod lpd8806;
 
 pub use apa102::Apa102;
 pub use sk6812::Sk6812;
 pub use ws2812::Ws2812;
+pub use lpd8806::Lpd8806;
 
 use crate::driver::ClocklessLed;
 

--- a/blinksy/src/leds/mod.rs
+++ b/blinksy/src/leds/mod.rs
@@ -15,7 +15,7 @@ mod lpd8806;
 pub use apa102::Apa102;
 pub use sk6812::Sk6812;
 pub use ws2812::Ws2812;
-pub use lpd8806::Lpd8806;
+pub use lpd8806::{Lpd8806, Lpd8806Brg};
 
 use crate::driver::ClocklessLed;
 


### PR DESCRIPTION
Add support for LPD8806 (for ex. https://www.adafruit.com/product/2546) led strips. I added two types:
- Lpd8806
- Lpd8806Brg
because the led strip should work correctly with GRB order but my personal led strip works correctly in BRG mode... I also found online other reports about this issue on some led strips with LPD8806. I have 32 leds 1d and they work correctly.