### PR TITLE
Add wrapper around MOSFET controlling V+ out connected to GPIO18 on GL-C-016WL-D

### DIFF
--- a/esp/gledopto/examples/ws2812-strip.rs
+++ b/esp/gledopto/examples/ws2812-strip.rs
@@ -8,13 +8,15 @@ use blinksy::{
     patterns::rainbow::{Rainbow, RainbowParams},
     ControlBuilder,
 };
-use gledopto::{board, bootloader, elapsed, main, ws2812};
+use gledopto::{board, bootloader, elapsed, main, power_control, ws2812};
 
 bootloader!();
 
 #[main]
 fn main() -> ! {
     let p = board!();
+
+    let mut power_control = power_control!(p);
 
     layout1d!(Layout, 50);
 
@@ -26,6 +28,7 @@ fn main() -> ! {
         .build();
 
     control.set_brightness(0.2);
+    power_control.turn_on();
 
     loop {
         let elapsed_in_ms = elapsed().as_millis();

--- a/esp/gledopto/src/lib.rs
+++ b/esp/gledopto/src/lib.rs
@@ -152,6 +152,9 @@ pub use esp_println as println;
 /// Button handling functionality
 pub mod button;
 
+/// Power control handling functionality
+pub mod power_control;
+
 /// Initializes the heap allocator with a 72KB heap.
 ///
 /// This is required for ESP32 targets that need dynamic memory allocation.
@@ -192,6 +195,13 @@ macro_rules! board {
 macro_rules! function_button {
     ($peripherals:ident) => {
         $crate::button::FunctionButton::new($peripherals.GPIO0)
+    };
+}
+
+#[macro_export]
+macro_rules! power_control {
+    ($peripherals:ident) => {
+        $crate::power_control::PowerControl::new($peripherals.GPIO18);
     };
 }
 

--- a/esp/gledopto/src/power_control.rs
+++ b/esp/gledopto/src/power_control.rs
@@ -1,0 +1,56 @@
+//! # Power control Handling Module
+//!
+//! This module provides functionality for controlling output power (V+ out) via
+//! on board MOSFET connected to GPIO18
+//!
+//! ## Features
+//!
+//! - Turn output power on and off
+//!
+//! ## Example
+//!
+//! ```rust
+//! use gledopto::{board, power_control, main};
+//!
+//! #[main]
+//! fn main() -> ! {
+//!     let p = board!();
+//!     let mut power_control = power_control!(p);
+//!
+//!     power_control.turn_on();
+//! }
+//! ```
+
+use esp_hal::{
+    gpio::{Level, Output, OutputConfig},
+    peripherals::GPIO18,
+};
+
+pub struct PowerControl<'a> {
+    control_pin: Output<'a>,
+}
+
+impl<'a> PowerControl<'a> {
+    /// Creates a new power control instance.
+    ///
+    /// # Arguments
+    ///
+    /// - `pin` - The GPIO pin connected to the power MOSFET (GPIO18)
+    ///
+    /// # Returns
+    ///
+    /// A configured PowerControl instance
+    pub fn new(pin: GPIO18<'a>) -> Self {
+        Self {
+            control_pin: Output::new(pin, Level::Low, OutputConfig::default()),
+        }
+    }
+
+    pub fn turn_on(&mut self) {
+        self.control_pin.set_high();
+    }
+
+    pub fn turn_off(&mut self) {
+        self.control_pin.set_low();
+    }
+}


### PR DESCRIPTION
I've just got a Gledopto controller in the mail. It turned out, that they have added a MOSFET into power line. In case, that you want to use `V+` output, one needs to turn it on to get voltage on it. It is hooked to `GPIO18`.

![PXL_20251126_115354517~2](https://github.com/user-attachments/assets/290ff09f-cf58-4f29-b52d-bfa7ca217d19)

I have bodged together a wrapper to control it. But I am a complete Rust newbie, so please excuse a potential incorrectness of the implementation.