### PR TITLE
desktop: Add an emulated button capability that uses keycodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,11 +68,13 @@ name = "blinksy-desktop"
 version = "0.11.0"
 dependencies = [
  "blinksy",
+ "button-driver",
  "egui",
  "egui-miniquad",
  "glam",
  "heapless",
  "miniquad",
+ "rand",
 ]
 
 [[package]]
@@ -89,6 +91,12 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "button-driver"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6275c5efc1b0c65e7d9bcd419112bec6b2901feeaac63605fc735a0dcea83c63"
 
 [[package]]
 name = "bytemuck"
@@ -158,6 +166,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +206,15 @@ dependencies = [
  "objc2-foundation",
  "smithay-clipboard",
  "x11-clipboard",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -288,7 +316,7 @@ dependencies = [
  "bytemuck",
  "copypasta",
  "egui",
- "getrandom",
+ "getrandom 0.2.16",
  "miniquad",
  "quad-rand",
  "quad-url",
@@ -383,6 +411,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core",
 ]
 
 [[package]]
@@ -777,6 +817,29 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"

--- a/blinksy-desktop/Cargo.toml
+++ b/blinksy-desktop/Cargo.toml
@@ -14,8 +14,12 @@ categories = ["multimedia", "rendering"]
 
 [dependencies]
 blinksy = { path = "../blinksy", version = "0.11" }
+button-driver = { version = "0.2.5", features = ["std"] }
 egui = "0.28"
 egui-miniquad = "0.15.0"
 glam = { version = "0.30.1" }
 heapless = "0.9.1"
 miniquad = "0.4"
+
+[dev-dependencies]
+rand = "0.10.2"

--- a/blinksy-desktop/examples/1d-button.rs
+++ b/blinksy-desktop/examples/1d-button.rs
@@ -1,0 +1,89 @@
+use blinksy::{
+    color::Okhsv, layout::Layout1d, layout1d, markers::Dim1d, pattern::Pattern, ControlBuilder,
+};
+use blinksy_desktop::{
+    button::DesktopButton,
+    driver::KeyCode,
+    driver::{Desktop, DesktopError},
+    time::elapsed_in_ms,
+};
+use std::{thread::sleep, time::Duration};
+
+layout1d!(StripLayout, 30);
+
+pub struct FlatParams {
+    color: Okhsv,
+}
+
+impl Default for FlatParams {
+    fn default() -> Self {
+        Self {
+            color: Okhsv::new(0., 1.0, 1.0),
+        }
+    }
+}
+
+pub struct Flat(FlatParams);
+
+impl<Layout> Pattern<Dim1d, Layout> for Flat
+where
+    Layout: Layout1d,
+{
+    type Params = FlatParams;
+    type Color = Okhsv;
+
+    fn new(params: Self::Params) -> Self {
+        Self(params)
+    }
+
+    fn tick(&self, _time_in_ms: u64) -> impl Iterator<Item = Self::Color> {
+        Layout::points().map(|_x| self.0.color)
+    }
+
+    fn set_params(&mut self, params: Self::Params) {
+        self.0 = params;
+    }
+}
+
+fn main() {
+    // Press the space bar to change the color of the strip.
+    // This example only cares about single clicks, so we set the release and hold times really short.
+    let mut button = DesktopButton::new(
+        Duration::from_micros(900),
+        Duration::from_millis(1),
+        Duration::from_millis(1),
+    );
+    Desktop::new_1d::<StripLayout>()
+        .with_button(KeyCode::Space, &button)
+        .start(move |driver| {
+            let mut control = ControlBuilder::new_1d()
+                .with_layout::<StripLayout, { StripLayout::PIXEL_COUNT }>()
+                .with_pattern::<Flat>(FlatParams::default())
+                .with_driver(driver)
+                .with_frame_buffer_size::<{ StripLayout::PIXEL_COUNT }>()
+                .build();
+
+            loop {
+                button.tick();
+                // Note that `button.held_time()` only reports after the button is released,
+                // so if the user holds the button down for a long time, it won't report that until they let go.
+                // If you want to detect and action long presses sooner, you can use `button.current_holding_time()`, but note that
+                // that reports repeatedly while the button is being held.
+                //
+                // The `button-driver` crate is capable of reporting on double and triple clicks, but we have deliberately tuned the
+                // driver timing on this example to map them into singles.
+                if button.is_clicked() || button.held_time().is_some() {
+                    println!("Button activated! Changing color...");
+                    let new_color = Okhsv::new(rand::random(), 1.0, 1.0);
+                    control.set_pattern_params(FlatParams { color: new_color });
+                }
+                button.reset();
+
+                if let Err(DesktopError::WindowClosed) = control.tick(elapsed_in_ms()) {
+                    break;
+                }
+
+                sleep(Duration::from_millis(16));
+            }
+        });
+}

--- a/blinksy-desktop/src/button.rs
+++ b/blinksy-desktop/src/button.rs
@@ -1,0 +1,84 @@
+//! # Fake desktop button input
+//! This module provides an emulated button input system like that of [`gledopto::button::FunctionButton`].
+
+use std::{
+    ops::{Deref, DerefMut},
+    sync::{atomic::AtomicBool, Arc},
+    time::{Duration, Instant},
+};
+
+use button_driver::{Button, ButtonConfig, Mode, PinWrapper};
+
+pub type ButtonState = Arc<AtomicBool>;
+
+/// An emulated button input which maps a keypress to [`button-driver`].
+///
+/// The idea is, if you want to use a button in your embedded application,
+/// you can use this to preview its behaviour on the desktop.
+///
+/// Internally it keeps an `Arc<AtomicBool>` so state can be injected by the desktop driver.
+/// See the `1d-button` example.
+///
+pub struct DesktopButton {
+    button: Button<DesktopInput, Instant, Duration>,
+}
+
+impl Default for DesktopButton {
+    fn default() -> Self {
+        Self::new(
+            ButtonConfig::<Duration>::default().debounce,
+            ButtonConfig::<Duration>::default().release,
+            ButtonConfig::<Duration>::default().hold,
+        )
+    }
+}
+
+impl DesktopButton {
+    /// Constructor with explicit configuration times
+    pub fn new(debounce: Duration, release: Duration, hold: Duration) -> Self {
+        let input = DesktopInput::default();
+        let config = ButtonConfig::<Duration> {
+            debounce,
+            release,
+            hold,
+            mode: Mode::PullDown,
+        };
+        let button = Button::new(input, config);
+        Self { button }
+    }
+
+    /// Returns a clone of the internal `Arc<AtomicBool>` so that it can be shared with other threads.
+    pub fn clone_state(&self) -> ButtonState {
+        self.button.pin.0.clone()
+    }
+}
+
+impl Deref for DesktopButton {
+    type Target = Button<DesktopInput, Instant, Duration>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.button
+    }
+}
+
+impl DerefMut for DesktopButton {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.button
+    }
+}
+
+pub struct DesktopInput(ButtonState);
+impl Default for DesktopInput {
+    fn default() -> Self {
+        Self(Arc::new(AtomicBool::new(false)))
+    }
+}
+
+impl PinWrapper for DesktopInput {
+    fn is_high(&mut self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::SeqCst)
+    }
+    fn is_low(&mut self) -> bool {
+        !self.0.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}

--- a/blinksy-desktop/src/driver.rs
+++ b/blinksy-desktop/src/driver.rs
@@ -67,10 +67,14 @@ use blinksy::{
     markers::{Dim1d, Dim2d, Dim3d},
 };
 use core::{fmt, marker::PhantomData};
+use egui::ahash::{HashMap, HashMapExt as _};
 use egui_miniquad as egui_mq;
 use glam::{vec3, Mat4, Vec3, Vec4, Vec4Swizzles};
+pub use miniquad::KeyCode;
 use miniquad::*;
 use std::sync::mpsc::{channel, Receiver, SendError, Sender};
+
+use crate::button::{ButtonState, DesktopButton};
 
 /// Configuration options for the desktop simulator.
 ///
@@ -125,6 +129,7 @@ impl Default for DesktopConfig {
 pub struct Desktop<Dim, Layout> {
     driver: DesktopDriver<Dim, Layout>,
     stage: DesktopStageOptions,
+    buttons: HashMap<KeyCode, ButtonState>,
 }
 
 impl Desktop<Dim1d, ()> {
@@ -187,7 +192,11 @@ impl Desktop<Dim1d, ()> {
             is_window_closed: is_window_closed_2,
         };
 
-        Desktop { driver, stage }
+        Desktop {
+            driver,
+            stage,
+            buttons: HashMap::new(),
+        }
     }
 }
 
@@ -252,7 +261,11 @@ impl Desktop<Dim2d, ()> {
             is_window_closed: is_window_closed_2,
         };
 
-        Desktop { driver, stage }
+        Desktop {
+            driver,
+            stage,
+            buttons: HashMap::new(),
+        }
     }
 }
 
@@ -317,7 +330,11 @@ impl Desktop<Dim3d, ()> {
             is_window_closed: is_window_closed_2,
         };
 
-        Desktop { driver, stage }
+        Desktop {
+            driver,
+            stage,
+            buttons: HashMap::new(),
+        }
     }
 }
 
@@ -330,11 +347,23 @@ where
     where
         F: 'static + FnOnce(DesktopDriver<Dim, Layout>) + Send,
     {
-        let Self { driver, stage } = self;
+        let Self {
+            driver,
+            stage,
+            buttons,
+        } = self;
 
         std::thread::spawn(move || f(driver));
 
-        DesktopStage::start(move || DesktopStage::new(stage));
+        DesktopStage::start(move || DesktopStage::new(stage, buttons));
+    }
+
+    /// Registers a keycode to be treated as a button input.
+    /// Take care not to conflict with the keys used for camera control (R,O) to avoid surprising behavior.
+    pub fn with_button(mut self, keycode: KeyCode, button: &DesktopButton) -> Self {
+        let state = button.clone_state();
+        self.buttons.insert(keycode, state);
+        self
     }
 }
 
@@ -990,6 +1019,7 @@ struct DesktopStage {
     ui_manager: UiManager,
     led_picker: LedPicker,
     renderer: Renderer,
+    buttons: HashMap<KeyCode, ButtonState>,
 }
 
 impl DesktopStage {
@@ -1010,7 +1040,7 @@ impl DesktopStage {
     }
 
     /// Create a new DesktopStage with the given LED positions, colors, and configuration.
-    fn new(options: DesktopStageOptions) -> Self {
+    fn new(options: DesktopStageOptions, buttons: HashMap<KeyCode, ButtonState>) -> Self {
         let DesktopStageOptions {
             positions,
             receiver,
@@ -1056,6 +1086,7 @@ impl DesktopStage {
             ui_manager,
             led_picker,
             renderer,
+            buttons,
         };
 
         // Setup buffers
@@ -1226,10 +1257,16 @@ impl EventHandler for DesktopStage {
         if !self.ui_manager.want_mouse_capture {
             self.handle_camera_input(keycode);
         }
+        if let Some(button_state) = self.buttons.get_mut(&keycode) {
+            button_state.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
     }
 
     fn key_up_event(&mut self, keycode: KeyCode, keymods: KeyMods) {
         self.ui_manager.key_up_event(keycode, keymods);
+        if let Some(button_state) = self.buttons.get_mut(&keycode) {
+            button_state.store(false, std::sync::atomic::Ordering::Relaxed);
+        }
     }
 
     fn char_event(&mut self, character: char, _keymods: KeyMods, _repeat: bool) {

--- a/blinksy-desktop/src/lib.rs
+++ b/blinksy-desktop/src/lib.rs
@@ -53,3 +53,6 @@ pub mod driver;
 
 /// Time utilities
 pub mod time;
+
+/// Fake button input
+pub mod button;

--- a/blinksy/src/control.rs
+++ b/blinksy/src/control.rs
@@ -167,6 +167,15 @@ where
     pub fn set_color_correction(&mut self, correction: ColorCorrection) {
         self.correction = correction;
     }
+
+    /// Updates the pattern's configuration.
+    ///
+    /// # Arguments
+    ///
+    /// - `params` - The new configuration parameters for the pattern
+    pub fn set_pattern_params(&mut self, params: Pattern::Params) {
+        self.pattern.set_params(params);
+    }
 }
 
 impl<const PIXEL_COUNT: usize, const FRAME_BUFFER_SIZE: usize, Dim, Layout, Pattern, Driver>

--- a/blinksy/src/pattern.rs
+++ b/blinksy/src/pattern.rs
@@ -94,4 +94,18 @@ where
     ///
     /// An iterator yielding one color per LED in the layout
     fn tick(&self, time_in_ms: u64) -> impl Iterator<Item = Self::Color>;
+
+    /// Updates the pattern's configuration.
+    ///
+    /// # Arguments
+    ///
+    /// - `params` - The new configuration parameters for the pattern
+    ///
+    /// Most patterns will have an implementation like this:
+    /// ```skip
+    ///     fn set_params(&mut self, params: Self::Params) {
+    ///         self.params = params;
+    ///     }
+    /// ```
+    fn set_params(&mut self, params: Self::Params);
 }

--- a/blinksy/src/patterns/noise.rs
+++ b/blinksy/src/patterns/noise.rs
@@ -123,6 +123,11 @@ where
         }
     }
 
+    /// Updates the pattern configuration while it's running.
+    fn set_params(&mut self, params: Self::Params) {
+        self.params = params;
+    }
+
     /// Generates colors for a 1D layout using noise.
     ///
     /// The pattern uses the LED position and time as inputs to a 2D noise function,
@@ -181,6 +186,11 @@ where
             value_noise: Noise::default().seed(1),
             params,
         }
+    }
+
+    /// Updates the pattern configuration while it's running.
+    fn set_params(&mut self, params: Self::Params) {
+        self.params = params;
     }
 
     /// Generates colors for a 2D layout using noise.
@@ -248,6 +258,11 @@ where
             value_noise: Noise::default().seed(1),
             params,
         }
+    }
+
+    /// Updates the pattern configuration while it's running.
+    fn set_params(&mut self, params: Self::Params) {
+        self.params = params;
     }
 
     /// Generates colors for a 3D layout using noise.

--- a/blinksy/src/patterns/noise.rs
+++ b/blinksy/src/patterns/noise.rs
@@ -72,7 +72,7 @@ pub mod noise_fns {
 }
 
 /// Configuration parameters for noise patterns.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct NoiseParams {
     /// Controls the speed of animation (higher = faster)

--- a/blinksy/src/patterns/rainbow.rs
+++ b/blinksy/src/patterns/rainbow.rs
@@ -78,6 +78,11 @@ where
         Self { params }
     }
 
+    /// Updates the pattern configuration while it's running.
+    fn set_params(&mut self, params: Self::Params) {
+        self.params = params;
+    }
+
     /// Generates colors for a 1D layout.
     ///
     /// The rainbow pattern creates a smooth transition of hues across the layout,
@@ -113,6 +118,11 @@ where
         Self { params }
     }
 
+    /// Updates the pattern configuration while it's running.
+    fn set_params(&mut self, params: Self::Params) {
+        self.params = params;
+    }
+
     /// Generates colors for a 2D layout.
     ///
     /// In 2D, the rainbow pattern uses the x-coordinate to determine hue,
@@ -146,6 +156,11 @@ where
     /// Creates a new Rainbow pattern with the specified parameters.
     fn new(params: Self::Params) -> Self {
         Self { params }
+    }
+
+    /// Updates the pattern configuration while it's running.
+    fn set_params(&mut self, params: Self::Params) {
+        self.params = params;
     }
 
     /// Generates colors for a 3D layout.

--- a/blinksy/src/patterns/rainbow.rs
+++ b/blinksy/src/patterns/rainbow.rs
@@ -37,7 +37,7 @@ use crate::{
 };
 
 /// Configuration parameters for the Rainbow pattern.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct RainbowParams {
     /// Controls the speed of the animation (higher = faster)

--- a/justfile
+++ b/justfile
@@ -23,6 +23,9 @@ desktop-3d-cube-volume-noise:
 desktop-3d-arcs:
   cargo run --release --example 3d-arcs
 
+desktop-button:
+  cargo run --release --example 1d-button
+
 gledopto-ws2812-strip:
   cd esp && cargo run --release -p gledopto --example ws2812-strip --features gl_c_016wl_d
 


### PR DESCRIPTION
I wanted to use the gledopto's function button, but also wanted to test out the button behaviour on the desktop. This is the result.