### PR TITLE
Add click callback for desktop driver

### DIFF
--- a/blinksy-desktop/examples/1d-rainbow.rs
+++ b/blinksy-desktop/examples/1d-rainbow.rs
@@ -14,6 +14,8 @@ layout1d!(StripLayout, 30);
 
 fn main() {
     Desktop::new_1d::<StripLayout>().start(|driver| {
+        // Keep a click receiver before moving the driver into the control.
+        let led_clicks = driver.led_clicks();
         let mut control = ControlBuilder::new_1d()
             .with_layout::<StripLayout, { StripLayout::PIXEL_COUNT }>()
             .with_pattern::<Rainbow>(RainbowParams {
@@ -24,6 +26,10 @@ fn main() {
             .build();
 
         loop {
+            while let Some(led_index) = led_clicks.try_take_led_click() {
+                println!("LED {led_index} clicked");
+            }
+
             if let Err(DesktopError::WindowClosed) = control.tick(elapsed_in_ms()) {
                 break;
             }

--- a/blinksy-desktop/src/driver.rs
+++ b/blinksy-desktop/src/driver.rs
@@ -177,6 +177,7 @@ impl Desktop<Dim1d, ()> {
         }
 
         let (sender, receiver) = channel();
+        let (led_click_sender, led_click_receiver) = channel();
         let is_window_closed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let is_window_closed_2 = is_window_closed.clone();
 
@@ -186,11 +187,13 @@ impl Desktop<Dim1d, ()> {
             brightness: 1.0,
             correction: ColorCorrection::default(),
             sender,
+            led_click_receiver,
             is_window_closed,
         };
         let stage = DesktopStageOptions {
             positions,
             receiver,
+            led_click_sender,
             config,
             is_window_closed: is_window_closed_2,
         };
@@ -246,6 +249,7 @@ impl Desktop<Dim2d, ()> {
         }
 
         let (sender, receiver) = channel();
+        let (led_click_sender, led_click_receiver) = channel();
         let is_window_closed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let is_window_closed_2 = is_window_closed.clone();
 
@@ -255,11 +259,13 @@ impl Desktop<Dim2d, ()> {
             brightness: 1.0,
             correction: ColorCorrection::default(),
             sender,
+            led_click_receiver,
             is_window_closed,
         };
         let stage = DesktopStageOptions {
             positions,
             receiver,
+            led_click_sender,
             config,
             is_window_closed: is_window_closed_2,
         };
@@ -315,6 +321,7 @@ impl Desktop<Dim3d, ()> {
         }
 
         let (sender, receiver) = channel();
+        let (led_click_sender, led_click_receiver) = channel();
         let is_window_closed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let is_window_closed_2 = is_window_closed.clone();
 
@@ -324,11 +331,13 @@ impl Desktop<Dim3d, ()> {
             brightness: 1.0,
             correction: ColorCorrection::default(),
             sender,
+            led_click_receiver,
             is_window_closed,
         };
         let stage = DesktopStageOptions {
             positions,
             receiver,
+            led_click_sender,
             config,
             is_window_closed: is_window_closed_2,
         };
@@ -405,10 +414,18 @@ pub struct DesktopDriver<Dim, Layout> {
     brightness: f32,
     correction: ColorCorrection,
     sender: Sender<LedMessage>,
+    led_click_receiver: Receiver<usize>,
     is_window_closed: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl<Dim, Layout> DesktopDriver<Dim, Layout> {
+    /// Returns the next LED index clicked in the simulator, if one is pending.
+    ///
+    /// This method never blocks. Only successful primary-button LED picks emit events.
+    pub fn try_take_led_click(&self) -> Option<usize> {
+        self.led_click_receiver.try_recv().ok()
+    }
+
     fn send(&self, message: LedMessage) -> Result<(), DesktopError> {
         if self
             .is_window_closed
@@ -1056,6 +1073,7 @@ impl Renderer {
 struct DesktopStageOptions {
     pub positions: Vec<Vec3>,
     pub receiver: Receiver<LedMessage>,
+    pub led_click_sender: Sender<usize>,
     pub config: DesktopConfig,
     pub is_window_closed: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
@@ -1069,6 +1087,7 @@ struct DesktopStage {
     brightness: f32,
     correction: ColorCorrection,
     receiver: Receiver<LedMessage>,
+    led_click_sender: Sender<usize>,
     camera: Camera,
     config: DesktopConfig,
     is_window_closed: std::sync::Arc<std::sync::atomic::AtomicBool>,
@@ -1103,6 +1122,7 @@ impl DesktopStage {
         let DesktopStageOptions {
             positions,
             receiver,
+            led_click_sender,
             config,
             is_window_closed,
         } = options;
@@ -1136,6 +1156,7 @@ impl DesktopStage {
             brightness: 1.0,
             correction: ColorCorrection::default(),
             receiver,
+            led_click_sender,
             camera,
             config,
             is_window_closed,
@@ -1294,6 +1315,9 @@ impl EventHandler for DesktopStage {
             if !self.mouse_down {
                 // Only do picking when button is first pressed
                 self.led_picker.try_select_at(x, y, &self.camera);
+                if let Some(led_index) = self.led_picker.selected_led {
+                    let _ = self.led_click_sender.send(led_index);
+                }
             }
 
             self.mouse_down = true;
@@ -1335,6 +1359,33 @@ impl EventHandler for DesktopStage {
     fn quit_requested_event(&mut self) {
         self.is_window_closed
             .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_take_led_click_returns_pending_clicks_in_order() {
+        let (sender, _) = channel();
+        let (led_click_sender, led_click_receiver) = channel();
+        let driver = DesktopDriver::<(), ()> {
+            dim: PhantomData,
+            layout: PhantomData,
+            brightness: 1.0,
+            correction: ColorCorrection::default(),
+            sender,
+            led_click_receiver,
+            is_window_closed: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        };
+
+        led_click_sender.send(2).unwrap();
+        led_click_sender.send(7).unwrap();
+
+        assert_eq!(driver.try_take_led_click(), Some(2));
+        assert_eq!(driver.try_take_led_click(), Some(7));
+        assert_eq!(driver.try_take_led_click(), None);
     }
 }
 

--- a/blinksy-desktop/src/driver.rs
+++ b/blinksy-desktop/src/driver.rs
@@ -75,7 +75,10 @@ use egui_miniquad as egui_mq;
 use glam::{vec3, Mat4, Vec3, Vec4, Vec4Swizzles};
 pub use miniquad::KeyCode;
 use miniquad::*;
-use std::sync::mpsc::{channel, Receiver, SendError, Sender};
+use std::sync::{
+    mpsc::{channel, Receiver, SendError, Sender},
+    Arc, Mutex,
+};
 
 use crate::button::{ButtonState, DesktopButton};
 
@@ -187,7 +190,9 @@ impl Desktop<Dim1d, ()> {
             brightness: 1.0,
             correction: ColorCorrection::default(),
             sender,
-            led_click_receiver,
+            led_click_receiver: LedClickReceiver {
+                receiver: Arc::new(Mutex::new(led_click_receiver)),
+            },
             is_window_closed,
         };
         let stage = DesktopStageOptions {
@@ -259,7 +264,9 @@ impl Desktop<Dim2d, ()> {
             brightness: 1.0,
             correction: ColorCorrection::default(),
             sender,
-            led_click_receiver,
+            led_click_receiver: LedClickReceiver {
+                receiver: Arc::new(Mutex::new(led_click_receiver)),
+            },
             is_window_closed,
         };
         let stage = DesktopStageOptions {
@@ -331,7 +338,9 @@ impl Desktop<Dim3d, ()> {
             brightness: 1.0,
             correction: ColorCorrection::default(),
             sender,
-            led_click_receiver,
+            led_click_receiver: LedClickReceiver {
+                receiver: Arc::new(Mutex::new(led_click_receiver)),
+            },
             is_window_closed,
         };
         let stage = DesktopStageOptions {
@@ -414,16 +423,21 @@ pub struct DesktopDriver<Dim, Layout> {
     brightness: f32,
     correction: ColorCorrection,
     sender: Sender<LedMessage>,
-    led_click_receiver: Receiver<usize>,
+    led_click_receiver: LedClickReceiver,
     is_window_closed: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl<Dim, Layout> DesktopDriver<Dim, Layout> {
+    /// Returns a handle for receiving LED click events while this driver is in use by a control.
+    pub fn led_clicks(&self) -> LedClickReceiver {
+        self.led_click_receiver.clone()
+    }
+
     /// Returns the next LED index clicked in the simulator, if one is pending.
     ///
     /// This method never blocks. Only successful primary-button LED picks emit events.
     pub fn try_take_led_click(&self) -> Option<usize> {
-        self.led_click_receiver.try_recv().ok()
+        self.led_click_receiver.try_take_led_click()
     }
 
     fn send(&self, message: LedMessage) -> Result<(), DesktopError> {
@@ -435,6 +449,23 @@ impl<Dim, Layout> DesktopDriver<Dim, Layout> {
         }
         self.sender.send(message)?;
         Ok(())
+    }
+}
+
+/// A non-blocking receiver for LED click events from the desktop simulator.
+///
+/// Obtain a handle with [`DesktopDriver::led_clicks`] before moving the driver into a control.
+#[derive(Clone)]
+pub struct LedClickReceiver {
+    receiver: Arc<Mutex<Receiver<usize>>>,
+}
+
+impl LedClickReceiver {
+    /// Returns the next LED index clicked in the simulator, if one is pending.
+    ///
+    /// This method never blocks. Only successful primary-button LED picks emit events.
+    pub fn try_take_led_click(&self) -> Option<usize> {
+        self.receiver.lock().ok()?.try_recv().ok()
     }
 }
 
@@ -1376,7 +1407,9 @@ mod tests {
             brightness: 1.0,
             correction: ColorCorrection::default(),
             sender,
-            led_click_receiver,
+            led_click_receiver: LedClickReceiver {
+                receiver: Arc::new(Mutex::new(led_click_receiver)),
+            },
             is_window_closed: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 

--- a/blinksy-desktop/src/lib.rs
+++ b/blinksy-desktop/src/lib.rs
@@ -30,6 +30,8 @@
 //!
 //! // Create the Desktop simulator
 //! Desktop::new_2d::<PanelLayout>().start(|driver| {
+//!     // Keep this receiver before moving the driver into the control.
+//!     let led_clicks = driver.led_clicks();
 //!     // Create a control using the desktop driver instead of physical hardware
 //!     let mut control = ControlBuilder::new_2d()
 //!         .with_layout::<PanelLayout, { PanelLayout::PIXEL_COUNT }>()
@@ -40,6 +42,10 @@
 //!
 //!     // Run your normal animation loop
 //!     loop {
+//!         while let Some(led_index) = led_clicks.try_take_led_click() {
+//!             println!("LED {led_index} clicked");
+//!         }
+//!
 //!         control.tick(elapsed_in_ms()).unwrap();
 //!
 //!         // Sleep on every frame (16 ms per frame ~= 60 frames per second)


### PR DESCRIPTION
Add a non-blocking LED-click event channel from the render thread to DesktopDriver, so desktop examples can consume selected LED indices via try_take_led_click() -> Option<usize>.                                      
